### PR TITLE
Added new args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,18 @@ fn main() {
         let recipient = args
             .recipient
             .expect("recipient argument is required for create_message");
+        let sender_subidentity = args
+            .sender_subidentity
+            .unwrap_or("".to_string());
+        let receiver_subidentity = args
+            .receiver_subidentity
+            .unwrap_or("".to_string());
+        let inbox = args
+            .inbox
+            .unwrap_or("".to_string());
+        let body_content = args
+            .body_content
+            .unwrap_or("body content".to_string());
         let other = args.other.unwrap_or("".to_string());
         let node2_encryption_pk =
             string_to_encryption_public_key(node2_encryption_pk_str.as_str()).unwrap();
@@ -138,13 +150,13 @@ fn main() {
                 node_keys.identity_secret_key,
                 node2_encryption_pk,
             )
-            .body("body content".to_string())
+            .body(body_content.to_string())
             .body_encryption(EncryptionMethod::None)
             .message_schema_type("schema type".to_string())
             .internal_metadata(
-                "".to_string(),
-                "".to_string(),
-                "".to_string(),
+                sender_subidentity.to_string(),
+                receiver_subidentity.to_string(),
+                inbox.to_string(),
                 EncryptionMethod::None,
             )
             .external_metadata(

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -7,6 +7,10 @@ pub struct Args {
     pub receiver_encryption_pk: Option<String>,
     pub recipient: Option<String>,
     pub other: Option<String>,
+    pub sender_subidentity: Option<String>,
+    pub receiver_subidentity: Option<String>,
+    pub inbox: Option<String>,
+    pub body_content: Option<String>,
 }
 
 pub fn parse_args() -> Args {
@@ -42,6 +46,30 @@ pub fn parse_args() -> Args {
                 .long("other")
                 .takes_value(true),
         )
+        .arg(
+            clap::Arg::new("sender_subidentity")
+                .short('s')
+                .long("sender_subidentity")
+                .takes_value(true),
+        )
+        .arg(
+            clap::Arg::new("receiver_subidentity")
+                .short('a')
+                .long("receiver_subidentity")
+                .takes_value(true),
+        )
+        .arg(
+            clap::Arg::new("inbox")
+                .short('i')
+                .long("inbox")
+                .takes_value(true),
+        )
+        .arg(
+            clap::Arg::new("body_content")
+                .short('b')
+                .long("body_content")
+                .takes_value(true),
+        )
         .get_matches();
 
     Args {
@@ -50,5 +78,9 @@ pub fn parse_args() -> Args {
         receiver_encryption_pk: matches.value_of("receiver_encryption_pk").map(String::from),
         recipient: matches.value_of("recipient").map(String::from),
         other: matches.value_of("other").map(String::from),
+        sender_subidentity: matches.value_of("sender_subidentity").map(String::from),
+        receiver_subidentity: matches.value_of("receiver_subidentity").map(String::from),
+        inbox: matches.value_of("inbox").map(String::from),
+        body_content: matches.value_of("body_content").map(String::from),
     }
 }


### PR DESCRIPTION
* added following command line args to have more flexibility when running `shinkai-node --create-message ...`
```
    pub sender_subidentity: Option<String>,
    pub receiver_subidentity: Option<String>,
    pub inbox: Option<String>,
    pub body_content: Option<String>
```