### PR TITLE
config(env): add NODE_STORAGE_PATH configurable base folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,9 @@ tmp_cron_downloads
 shinkai-mini-apps/shinkai-tray/src-tauri/models
 shinkai-mini-apps/shinkai-tray/src-tauri/db
 typescript
+shinkai-libs/shinkai-message-pyo3/env_x86_64
 .secret
 db/.secret
-vector_fs_db
-shinkai-libs/shinkai-message-pyo3/env_x86_64
+./main_db
+./vector_fs_db
+./storage/*

--- a/src/network/node.rs
+++ b/src/network/node.rs
@@ -240,7 +240,7 @@ pub enum NodeCommand {
     },
     APIIsPristine {
         res: Sender<Result<bool, APIError>>,
-    }
+    },
 }
 
 /// Hard-coded embedding model that is set as the default when creating a new profile.
@@ -308,7 +308,7 @@ impl Node {
         encryption_secret_key: EncryptionStaticKey,
         ping_interval_secs: u64,
         commands: Receiver<NodeCommand>,
-        db_path: String,
+        main_db_path: String,
         first_device_needs_registration_code: bool,
         initial_agents: Vec<SerializedAgent>,
         js_toolkit_executor_remote: Option<String>,
@@ -323,9 +323,9 @@ impl Node {
         }
 
         // Get public keys, and update the local node keys in the db
-        let db = ShinkaiDB::new(&db_path).unwrap_or_else(|e| {
+        let db = ShinkaiDB::new(&main_db_path).unwrap_or_else(|e| {
             eprintln!("Error: {:?}", e);
-            panic!("Failed to open database: {}", db_path)
+            panic!("Failed to open database: {}", main_db_path)
         });
         let db_arc = Arc::new(Mutex::new(db));
         let identity_public_key = identity_secret_key.verifying_key();

--- a/src/utils/environment.rs
+++ b/src/utils/environment.rs
@@ -17,9 +17,7 @@ pub struct NodeEnvironment {
     pub first_device_needs_registration_code: bool,
     pub js_toolkit_executor_remote: Option<String>,
     pub no_secrets_file: bool,
-    pub secrets_file_path: Option<String>,
-    pub main_db_path: Option<String>,
-    pub vector_fs_db_path: Option<String>,
+    pub node_storage_path: Option<String>,
     pub unstructured_server_url: Option<String>,
     pub unstructured_server_api_key: Option<String>,
     pub embeddings_server_url: Option<String>,
@@ -77,7 +75,7 @@ pub fn fetch_agent_env(global_identity: String) -> Vec<SerializedAgent> {
 }
 
 pub fn fetch_node_environment() -> NodeEnvironment {
-    let global_identity_name = env::var("GLOBAL_IDENTITY_NAME").unwrap_or("@@node1.shinkai".to_string());
+    let global_identity_name = env::var("GLOBAL_IDENTITY_NAME").unwrap_or("@@localhost.shinkai".to_string());
 
     // Fetch the environment variables for the IP and port, or use default values
     let ip: IpAddr = env::var("NODE_IP")
@@ -126,20 +124,20 @@ pub fn fetch_node_environment() -> NodeEnvironment {
 
     let js_toolkit_executor_remote: Option<String> = env::var("JS_TOOLKIT_ADDRESS").ok().filter(|s| !s.is_empty());
 
-    // secrets file env vars
     let no_secrets_file: bool = env::var("NO_secretsS_FILE")
         .unwrap_or_else(|_| "false".to_string())
         .parse()
         .expect("Failed to parse NO_secretsS_FILE");
-    let secrets_file_path: Option<String> = env::var("NODE_secretsS_FILE_PATH").ok();
-
-    // DB Path Env Vars
-    let main_db_path: Option<String> = env::var("NODE_MAIN_DB_PATH").ok();
-    let vector_fs_db_path: Option<String> = env::var("NODE_VEC_FS_DB_PATH").ok();
 
     // Define the address and port where your node will listen
     let listen_address = SocketAddr::new(ip, port);
     let api_listen_address = SocketAddr::new(api_ip, api_port);
+
+    // DB Path Env Vars
+    let node_storage_path: Option<String> = match env::var("NODE_STORAGE_PATH").ok() {
+        Some(val) => Some(val),
+        None => Some("storage".to_string()),
+    };
 
     // External server env vars
     let unstructured_server_url: Option<String> = env::var("UNSTRUCTURED_SERVER_URL").ok();
@@ -158,9 +156,7 @@ pub fn fetch_node_environment() -> NodeEnvironment {
         first_device_needs_registration_code,
         js_toolkit_executor_remote,
         no_secrets_file,
-        main_db_path,
-        vector_fs_db_path,
-        secrets_file_path,
+        node_storage_path,
         unstructured_server_url,
         unstructured_server_api_key,
         embeddings_server_url,

--- a/src/utils/keys.rs
+++ b/src/utils/keys.rs
@@ -21,9 +21,9 @@ pub struct NodeKeys {
     pub encryption_public_key: EncryptionPublicKey,
 }
 
-pub fn generate_or_load_keys() -> NodeKeys {
+pub fn generate_or_load_keys(secrets_file_path: &str) -> NodeKeys {
     // First check for .secret file
-    if let Ok(contents) = fs::read_to_string(Path::new("db").join(".secret")) {
+    if let Ok(contents) = fs::read_to_string(secrets_file_path) {
         // Parse the contents of the file
         let lines: HashMap<_, _> = contents
             .lines()


### PR DESCRIPTION
- if not set, default base storage will be a folder named `storage` on the binary path
- main node db parent path is named `main_db` and final path is built with `identity_public_key`
- vector fs db parent path is named ` vector_fs_db` and final path is built with `identity_public_key`
- secrets file is named `.secret` and lives within main storage folder

This is what it looks like when deployed:

```sh
storage
|   .secret
|   main_db
|   |   1ca74fbebce752d556beb89eb6d0d0912c3ba8f5ab6441d750b797a50675ec7c
|   |   |   000004.log
|   |   |   CURRENT
|   |   |   MANIFEST-000005
|   |   |   IDENTITY
|   |   |   LOCK
|   |   |   OPTIONS-000055
|   |   |   OPTIONS-000057
|   |   |   LOG
|   vector_fs_db
|   |   1ca74fbebce752d556beb89eb6d0d0912c3ba8f5ab6441d750b797a50675ec7c
|   |   |   LOG
|   |   |   IDENTITY
|   |   |   OPTIONS-000011
|   |   |   LOCK
|   |   |   000004.log
|   |   |   CURRENT
|   |   |   MANIFEST-000005
|   |   |   OPTIONS-000013
```