### PR TITLE
- fix: keyphrases library using 100% CPU to generate keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "keyphrases"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3469baa50de5674276e5328795aec868ab2cbf2e52ae830b7c36d39b737a4a2"
+checksum = "4a4e171437b3fc556d1b338ee2f3ea7353fc566b1784439aa077ebfb55da4d0a"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ uuid = { version = "0.8", features = ["v4"] }
 reqwest = { version = "0.11.24", features = ["json", "tokio-native-tls", "blocking"] }
 # llm = { git = "https://github.com/rustformers/llm", branch = "main" }
 ordered-float = "3.7.0"
-keyphrases = "0.3.2"
+keyphrases = "0.3.3"
 byteorder = "1.4.3"
 shinkai_message_primitives = { path = "./shinkai-libs/shinkai-message-primitives" }
 shinkai_vector_resources = { path = "./shinkai-libs/shinkai-vector-resources" }


### PR DESCRIPTION
See https://github.com/jjoeldaniel/keyphrases.rs/pull/8 to understand this change better