### PR TITLE
Parse URL metadata

### DIFF
--- a/files/parsed_channels.md
+++ b/files/parsed_channels.md
@@ -64,7 +64,7 @@ A Vector Resource is made up of a hierarchy of nodes, where each node can either
 
 ## Importing Into Your Project
 
-To disable [desktop-only](https://www.shinkai.com/) & support ![wasm](wasm.png), simply import <b>as such<b>:
+To disable [desktop-only](https://www.shinkai.com/) & support ![wasm](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/WebAssembly_Logo.svg/1200px-WebAssembly_Logo.svg.png), simply import <b>as such<b>:
 
 ```
 shinkai_vector_resources = { path = "../shinkai-vector-resources", default-features = false }

--- a/files/sample.html
+++ b/files/sample.html
@@ -9,6 +9,9 @@
   <h2>Introduction</h2>
   <p>
     Video processing solutions with AI have revolutionized the way we analyze and understand video content. By leveraging artificial intelligence algorithms, we can extract valuable insights from videos, automate tasks, and enhance video quality.
+    <img src="https://www.nvidia.com/content/dam/en-zz/Solutions/ai-on-rtx/nvidia-ai-on-rtx-100vp-d.jpg" alt="Video Processing with AI" width="800" height="600" />
+    <br />
+    <a href="https://www.colossyan.com/ai-video-creator?utm_term=ai%20video%20presenter&utm_campaign=AI+Video+Creator+Keywords+-+UK+-+EN&utm_source=adwords&utm_medium=ppc&hsa_acc=5380454562&hsa_cam=20646312124&hsa_grp=157357476911&hsa_ad=698838864859&hsa_src=g&hsa_tgt=kwd-1645934822849&hsa_kw=ai%20video%20presenter&hsa_mt=b&hsa_net=adwords&hsa_ver=3&gad_source=1&gclid=EAIaIQobChMI_Kqaup-KhgMVDq1oCR2aeg6ZEAAYAiAAEgKzUvD_BwE">AI Video generator</a>
   </p>
 
   <h2>Benefits of AI in Video Processing</h2>

--- a/shinkai-libs/shinkai-vector-resources/tests/vector_resource_tests.rs
+++ b/shinkai-libs/shinkai-vector-resources/tests/vector_resource_tests.rs
@@ -1192,6 +1192,29 @@ async fn local_md_parsing_test() {
         .get_text_content()
         .unwrap()
         .contains("A powerful native Rust"));
+
+    // Test URL metadata parsing
+    let query_string = "How to import into project?".to_string();
+    let query_embedding = generator.generate_embedding_default(&query_string).await.unwrap();
+    let results = resource.as_trait_object().vector_search(query_embedding, 3);
+
+    assert_eq!(
+        results[0].node.metadata.as_ref().unwrap().get("link-urls").unwrap(),
+        &serde_json::to_string(&vec!["[desktop-only](https://www.shinkai.com/)"]).unwrap()
+    );
+    assert!(results[0]
+        .node
+        .metadata
+        .as_ref()
+        .unwrap()
+        .get("image-urls")
+        .unwrap()
+        .contains("WebAssembly_Logo.svg"));
+    assert!(!results[0]
+        .node
+        .get_text_content()
+        .unwrap()
+        .contains("WebAssembly_Logo.svg"));
 }
 
 #[tokio::test]
@@ -1223,6 +1246,29 @@ async fn local_html_parsing_test() {
         .get_text_content()
         .unwrap()
         .contains("Traditional Methods"));
+
+    // Test URL metadata parsing
+    let query_string = "Show AI Video generator".to_string();
+    let query_embedding = generator.generate_embedding_default(&query_string).await.unwrap();
+    let results = resource.as_trait_object().vector_search(query_embedding, 3);
+
+    assert!(results[0].score > 0.7);
+    assert!(results[0]
+        .node
+        .metadata
+        .as_ref()
+        .unwrap()
+        .get("image-urls")
+        .unwrap()
+        .contains("Video Processing"));
+    assert!(results[0]
+        .node
+        .metadata
+        .as_ref()
+        .unwrap()
+        .get("link-urls")
+        .unwrap()
+        .contains("AI Video"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Parse link and image URLs in markdown and add them to the node's metadata.
- Shorten URLs in text to domain only.