### PR TITLE
- fix: vc redist windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6473,7 +6473,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_node"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shinkai_node"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 authors.workspace = true
 # this causes `cargo run` in the workspace root to run this package


### PR DESCRIPTION
Today, finally with @nicarq we found the problem producing the shinkai-node doesn't run when we embed it in shinkai-desktop.

shinkai-node for windows requires vc redist to run correctly in Windows machines (as most rust msvc apps). At this point it was relying on system libraries assuming vc redist was previously installed. To be honest, we couln't find what changed in the code from v0.7.9 to v0.7.10+ but shinkai-node started to use some VC Redist libraries from ollama resources (they are in the same folder when we embed it in shinkai-desktop) and it was producing that the node crash when we tried to start it.

With this PR we are including these dependencies as part of the bundle so now we shouldn't have this problem, let's say it's self contained.

To implement this we are adding `crt-static` flag to `x86_64-pc-windows-msvc` builds
Read more at [crt-static](https://rust-lang.github.io/rfcs/1721-crt-static.html)