### PR TITLE
- fix: wrong boolean condition on text groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7636,7 +7636,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_node"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shinkai_node"
-version = "0.7.22"
+version = "0.7.23"
 edition = "2021"
 authors.workspace = true
 # this causes `cargo run` in the workspace root to run this package

--- a/shinkai-bin/shinkai-node/tests/it/subscription_http_upload_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/subscription_http_upload_tests.rs
@@ -225,8 +225,8 @@ fn subscription_http_upload() {
                         "e8f4ee5dda589611c6b5ac06b551031f5e314a7bc130534d12ffc0860d6dac9b",
                     ),
                     (
-                        "/shinkai_sharing/zeko_mini.c57496ff.checksum",
-                        "6e5609f6b82ac769ad2fbf2c6781b7c687438800e0501c03e72c41b2c57496ff",
+                        "/shinkai_sharing/zeko_mini.b90941d9.checksum",
+                        "d7c996dc47390b3c1cb65e4c1ab03c035363b13b468195bfa6ab0d0eb90941d9",
                     ),
                     (
                         "/shinkai_sharing/shinkai_intro.0d6dac9b.checksum",
@@ -234,7 +234,7 @@ fn subscription_http_upload() {
                     ),
                     (
                         "/shinkai_sharing/zeko_mini",
-                        "6e5609f6b82ac769ad2fbf2c6781b7c687438800e0501c03e72c41b2c57496ff",
+                        "d7c996dc47390b3c1cb65e4c1ab03c035363b13b468195bfa6ab0d0eb90941d9",
                     ),
                 ];
 

--- a/shinkai-libs/shinkai-vector-resources/src/file_parser/unstructured_parser.rs
+++ b/shinkai-libs/shinkai-vector-resources/src/file_parser/unstructured_parser.rs
@@ -156,14 +156,13 @@ impl UnstructuredParser {
         }
 
         // Push the last group to title group or groups
-        if !current_group.text.len() < 2 {
+        if current_group.text.len() >= 2 {
             ShinkaiFileParser::push_group_to_appropriate_parent(current_group, &mut current_title_group, &mut groups);
         }
         // Push the last title group to groups
         if let Some(title_group) = current_title_group.take() {
             groups.push(title_group);
         }
-
         groups
     }
 


### PR DESCRIPTION
This wrong conditional grouping was producing VRKai's with no content on some special cases (IE when we have just 1 group).

FTR, here is a short example of this situation (for sure everything change if we add a parenthesis before the negation op)
```rust
    let len: usize = 1021;
    if !len < 2 {
        println!("1");
    }

    let len: i32 = 1021;
    if !len < 2 {
        println!("2");
    }

    // 2
```