### PR TITLE
Fix/save embeddings in tool data

### DIFF
--- a/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
@@ -3,7 +3,8 @@ use bytemuck::cast_slice;
 use keyphrases::KeyPhraseExtractor;
 use rusqlite::{params, Result};
 use shinkai_tools_primitives::tools::shinkai_tool::{ShinkaiTool, ShinkaiToolHeader};
-use std::collections::HashSet;
+use std::{collections::HashSet, string};
+use shinkai_vector_resources::embeddings::Embedding;
 
 impl SqliteManager {
     // Adds a ShinkaiTool entry to the shinkai_tools table
@@ -44,6 +45,8 @@ impl SqliteManager {
 
         // Clone the tool to make it mutable
         let mut tool_clone = tool.clone();
+        tool_clone.set_embedding(Embedding::new("", embedding.clone()));
+
 
         // Determine if the tool can be enabled
         let is_enabled = tool_clone.is_enabled() && tool_clone.can_be_enabled();

--- a/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
@@ -3,7 +3,7 @@ use bytemuck::cast_slice;
 use keyphrases::KeyPhraseExtractor;
 use rusqlite::{params, Result};
 use shinkai_tools_primitives::tools::shinkai_tool::{ShinkaiTool, ShinkaiToolHeader};
-use std::{collections::HashSet, string};
+use std::collections::HashSet;
 use shinkai_vector_resources::embeddings::Embedding;
 
 impl SqliteManager {

--- a/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
@@ -47,7 +47,6 @@ impl SqliteManager {
         let mut tool_clone = tool.clone();
         tool_clone.set_embedding(Embedding::new("", embedding.clone()));
 
-
         // Determine if the tool can be enabled
         let is_enabled = tool_clone.is_enabled() && tool_clone.can_be_enabled();
         if tool_clone.is_enabled() && !tool_clone.can_be_enabled() {


### PR DESCRIPTION
This pull request makes some modifications to the `shinkai_tool_manager.rs` file in the `shinkai-libs/shinkai-sqlite` directory. The changes involve adding a new dependency and updating the `SqliteManager` implementation to set embeddings for tools.

The most important changes include:

### Dependency Addition:
* Added `Embedding` from `shinkai_vector_resources::embeddings` to the imports.

### Implementation Update:
* Modified the `SqliteManager` implementation to set embeddings for tools by calling `tool_clone.set_embedding(Embedding::new("", embedding.clone()))`.