### PR TITLE
Refactor tool router key serialization and deserialization

### DIFF
--- a/shinkai-libs/shinkai-tools-primitives/src/tools/deno_tools.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/deno_tools.rs
@@ -31,7 +31,8 @@ pub struct DenoTool {
     pub version: String,
     pub js_code: String,
     #[serde(default)]
-    #[serde(deserialize_with = "deserialize_tool_router_keys")]
+    #[serde(deserialize_with = "ToolRouterKey::deserialize_tool_router_keys")]
+    #[serde(serialize_with = "ToolRouterKey::serialize_tool_router_keys")]
     pub tools: Option<Vec<ToolRouterKey>>,
     pub config: Vec<ToolConfig>,
     pub description: String,
@@ -46,24 +47,6 @@ pub struct DenoTool {
     pub file_inbox: Option<String>,
     pub oauth: Option<Vec<OAuth>>,
     pub assets: Option<Vec<String>>,
-}
-
-fn deserialize_tool_router_keys<'de, D>(deserializer: D) -> Result<Option<Vec<ToolRouterKey>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let string_vec: Option<Vec<String>> = Option::deserialize(deserializer)?;
-
-    match string_vec {
-        Some(vec) => {
-            let router_keys = vec
-                .into_iter()
-                .filter_map(|s| ToolRouterKey::from_string(&s).ok())
-                .collect();
-            Ok(Some(router_keys))
-        }
-        None => Ok(None),
-    }
 }
 
 impl DenoTool {

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/python_tools.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/python_tools.rs
@@ -4,7 +4,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, thread};
 
 use crate::tools::error::ToolError;
-use serde::Deserialize;
 use shinkai_message_primitives::schemas::shinkai_name::ShinkaiName;
 use shinkai_message_primitives::schemas::tool_router_key::ToolRouterKey;
 use shinkai_tools_runner::tools::code_files::CodeFiles;
@@ -30,7 +29,9 @@ pub struct PythonTool {
     pub name: String,
     pub author: String,
     pub py_code: String,
-    #[serde(deserialize_with = "deserialize_tool_router_keys")]
+    #[serde(default)]
+    #[serde(deserialize_with = "ToolRouterKey::deserialize_tool_router_keys")]
+    #[serde(serialize_with = "ToolRouterKey::serialize_tool_router_keys")]
     pub tools: Option<Vec<ToolRouterKey>>,
     pub config: Vec<ToolConfig>,
     pub description: String,
@@ -45,25 +46,6 @@ pub struct PythonTool {
     pub file_inbox: Option<String>,
     pub oauth: Option<Vec<OAuth>>,
     pub assets: Option<Vec<String>>,
-}
-
-fn deserialize_tool_router_keys<'de, D>(deserializer: D) -> Result<Option<Vec<ToolRouterKey>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let string_vec: Option<Vec<String>> = Option::deserialize(deserializer)?;
-
-    match string_vec {
-        Some(vec) => {
-            let router_keys = vec
-                .into_iter()
-                .map(|s| ToolRouterKey::from_string(&s))
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(serde::de::Error::custom)?;
-            Ok(Some(router_keys))
-        }
-        None => Ok(None),
-    }
 }
 
 impl PythonTool {


### PR DESCRIPTION
- Implemented `deserialize_tool_router_keys` and `serialize_tool_router_keys` methods in `ToolRouterKey` for improved handling of tool router keys.
- Updated `DenoTool` and `PythonTool` structs to use the new serialization and deserialization methods, removing redundant local functions.
- Enhanced code clarity and maintainability by centralizing serialization logic.