### PR TITLE
Enhance IDE/editor opening fallback mechanism

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_tools.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_tools.rs
@@ -3165,11 +3165,15 @@ start().then(() => {{
             })?;
 
         // First try to open with cursor
-        let cursor_open = Command::new("code").arg(temp_dir.clone()).spawn();
+        let cursor_open = Command::new("cursor").arg(temp_dir.clone()).spawn();
         if cursor_open.is_err() {
-            // If cursor fails, try with open
-            // Ignore error if any.
-            let _ = open::that(temp_dir.clone());
+            // If cursor fails try with the "code" command
+            let code_open = Command::new("code").arg(temp_dir.clone()).spawn();
+            if code_open.is_err() {
+                // If cursor and code fails, try with open
+                // Ignore error if any.
+                let _ = open::that(temp_dir.clone());
+            }
         }
 
         // Create parameters.json


### PR DESCRIPTION
- Prioritize opening with Cursor IDE
- Add fallback to VS Code if Cursor fails
- Use generic open method as final fallback