### PR TITLE
fix: identity created quest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6650,7 +6650,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shinkai-spreadsheet-llm"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6665,7 +6665,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_crypto_identities"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "chrono",
  "dashmap",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_embedding"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_fs"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_http_api"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-channel 1.9.0",
  "bytes",
@@ -6761,7 +6761,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_job_queue_manager"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "chrono",
  "serde",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_message_primitives"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6803,14 +6803,14 @@ dependencies = [
 
 [[package]]
 name = "shinkai_mini_libs"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "base64 0.22.1",
 ]
 
 [[package]]
 name = "shinkai_node"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_ocr"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "image 0.25.5",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_sheet"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-channel 1.9.0",
  "chrono",
@@ -6913,7 +6913,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_sqlite"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "bincode",
  "blake3",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_tcp_relayer"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "chrono",
  "clap 3.2.25",
@@ -6963,7 +6963,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_tools_primitives"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 authors = ["Nico Arqueros <nico@shinkai.com>"]
 

--- a/shinkai-bin/shinkai-node/src/managers/galxe_quests.rs
+++ b/shinkai-bin/shinkai-node/src/managers/galxe_quests.rs
@@ -324,7 +324,7 @@ pub async fn compute_create_identity_quest(
     .await
     .map_err(|e| format!("Failed to create registry: {}", e))?;
 
-    let onchain_identity = match registry.get_identity_record(node_name.to_string()).await {
+    let onchain_identity = match registry.get_identity_record(node_name.to_string(), Some(true)).await {
         Ok(identity) => identity,
         Err(e) => {
             println!("Identity not found in registry: {}", e);

--- a/shinkai-bin/shinkai-node/src/managers/identity_network_manager.rs
+++ b/shinkai-bin/shinkai-node/src/managers/identity_network_manager.rs
@@ -32,11 +32,12 @@ impl IdentityNetworkManager {
     pub async fn external_identity_to_profile_data(
         &self,
         global_identity: String,
+        force_refresh: Option<bool>,
     ) -> Result<OnchainIdentity, &'static str> {
         let record = {
             let identity = global_identity.trim_start_matches("@@");
             let registry = self.registry.lock().await;
-            match registry.get_identity_record(identity.to_string()).await {
+            match registry.get_identity_record(identity.to_string(), force_refresh).await {
                 Ok(record) => record,
                 Err(_) => return Err("Unrecognized global identity"),
             }
@@ -53,7 +54,10 @@ impl IdentityNetworkManager {
             let proxy_identity = record.address_or_proxy_nodes.clone();
             let proxy_record = {
                 let registry = self.registry.lock().await;
-                match registry.get_identity_record(proxy_identity.join(",")).await {
+                match registry
+                    .get_identity_record(proxy_identity.join(","), force_refresh)
+                    .await
+                {
                     Ok(record) => record,
                     Err(_) => return Err("Failed to fetch proxy node data"),
                 }

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/external_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/external_agent_offerings_manager.rs
@@ -10,7 +10,7 @@ use ed25519_dalek::SigningKey;
 use futures::Future;
 use shinkai_job_queue_manager::job_queue_manager::JobQueueManager;
 use shinkai_message_primitives::schemas::invoices::{
-    Invoice, InvoiceError, InvoiceRequest, InvoiceRequestNetworkError, InvoiceStatusEnum,
+    Invoice, InvoiceError, InvoiceRequest, InvoiceRequestNetworkError, InvoiceStatusEnum
 };
 use shinkai_message_primitives::schemas::shinkai_name::ShinkaiName;
 use shinkai_message_primitives::schemas::shinkai_tool_offering::{ShinkaiToolOffering, UsageType, UsageTypeInquiry};
@@ -382,7 +382,8 @@ impl ExtAgentOfferingsManager {
     ///
     /// # Returns
     ///
-    /// * `Pin<Box<dyn Future<Output = Result<String, AgentOfferingManagerError>> + Send + 'static>>` - A future that resolves to the result of the processing.
+    /// * `Pin<Box<dyn Future<Output = Result<String, AgentOfferingManagerError>> + Send + 'static>>` - A future that
+    ///   resolves to the result of the processing.
     #[allow(clippy::too_many_arguments)]
     fn process_invoice_payment(
         _invoice: Invoice,
@@ -637,7 +638,7 @@ impl ExtAgentOfferingsManager {
                 if let Some(identity_manager_arc) = self.identity_manager.upgrade() {
                     let identity_manager = identity_manager_arc.lock().await;
                     let standard_identity = identity_manager
-                        .external_profile_to_global_identity(&invoice_request.requester_name.to_string())
+                        .external_profile_to_global_identity(&invoice_request.requester_name.to_string(), None)
                         .await
                         .map_err(|e| AgentOfferingManagerError::OperationFailed(e))?;
                     drop(identity_manager);
@@ -678,7 +679,7 @@ impl ExtAgentOfferingsManager {
         if let Some(identity_manager_arc) = self.identity_manager.upgrade() {
             let identity_manager = identity_manager_arc.lock().await;
             let standard_identity = identity_manager
-                .external_profile_to_global_identity(&invoice_request.requester_name.to_string())
+                .external_profile_to_global_identity(&invoice_request.requester_name.to_string(), None)
                 .await
                 .map_err(|e| AgentOfferingManagerError::OperationFailed(e))?;
             drop(identity_manager);
@@ -794,9 +795,10 @@ impl ExtAgentOfferingsManager {
 
         // TODO: update the db and mark the invoice as paid (maybe after the job is done)
         // Note: what happens if the job fails? should we retry and then good-luck with the payment?
-        // Should we actually receive the job input before the payment so we can confirm that we are "comfortable" with the job?
-        // What happens if you want to crawl a website, but the website is down? should we refund the payment?
-        // What happens if the job is done, but the requester is not happy with the result? should we refund the payment?
+        // Should we actually receive the job input before the payment so we can confirm that we are "comfortable" with
+        // the job? What happens if you want to crawl a website, but the website is down? should we refund the
+        // payment? What happens if the job is done, but the requester is not happy with the result? should we
+        // refund the payment?
 
         Ok(local_invoice)
     }
@@ -826,7 +828,7 @@ impl ExtAgentOfferingsManager {
         if let Some(identity_manager_arc) = self.identity_manager.upgrade() {
             let identity_manager = identity_manager_arc.lock().await;
             let standard_identity = identity_manager
-                .external_profile_to_global_identity(&requester_node_name.to_string())
+                .external_profile_to_global_identity(&requester_node_name.to_string(), None)
                 .await
                 .map_err(|e| AgentOfferingManagerError::OperationFailed(e))?;
             drop(identity_manager);
@@ -871,11 +873,9 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use shinkai_message_primitives::{
-        schemas::identity::{Identity, StandardIdentity, StandardIdentityType},
-        shinkai_message::shinkai_message_schemas::IdentityPermissions,
-        shinkai_utils::{
-            encryption::unsafe_deterministic_encryption_keypair, signatures::unsafe_deterministic_signature_keypair,
-        },
+        schemas::identity::{Identity, StandardIdentity, StandardIdentityType}, shinkai_message::shinkai_message_schemas::IdentityPermissions, shinkai_utils::{
+            encryption::unsafe_deterministic_encryption_keypair, signatures::unsafe_deterministic_signature_keypair
+        }
     };
 
     #[derive(Clone, Debug)]
@@ -932,6 +932,7 @@ mod tests {
         async fn external_profile_to_global_identity(
             &self,
             _full_profile_name: &str,
+            _: Option<bool>,
         ) -> Result<StandardIdentity, String> {
             unimplemented!()
         }
@@ -997,10 +998,11 @@ mod tests {
     //     // Initialize ShinkaiDB
     //     let shinkai_db = match ShinkaiDB::new("shinkai_db_tests/shinkaidb") {
     //         Ok(db) => Arc::new(db),
-    //         Err(e) => return Err(SqliteManagerError::DatabaseError(rusqlite::Error::InvalidParameterName(e.to_string()))),
-    //     };
+    //         Err(e) => return
+    // Err(SqliteManagerError::DatabaseError(rusqlite::Error::InvalidParameterName(e.to_string()))),     };
 
-    //     let sqlite_manager = SqliteManager::new("sqlite_tests".to_string(), "".to_string(), embedding_model).unwrap();
+    //     let sqlite_manager = SqliteManager::new("sqlite_tests".to_string(), "".to_string(),
+    // embedding_model).unwrap();
 
     //     let tools = built_in_tools::get_tools();
 

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
@@ -5,32 +5,22 @@ use serde_json::Value;
 
 use shinkai_message_primitives::{
     schemas::{
-        invoices::{InternalInvoiceRequest, Invoice, InvoiceStatusEnum, Payment},
-        shinkai_name::ShinkaiName,
-        shinkai_proxy_builder_info::ShinkaiProxyBuilderInfo,
-        shinkai_tool_offering::{ToolPrice, UsageTypeInquiry},
-        wallet_mixed::AddressBalanceList,
-    },
-    shinkai_message::shinkai_message_schemas::MessageSchemaType,
-    shinkai_utils::{
-        encryption::clone_static_secret_key, shinkai_message_builder::ShinkaiMessageBuilder,
-        signatures::clone_signature_secret_key,
-    },
+        invoices::{InternalInvoiceRequest, Invoice, InvoiceStatusEnum, Payment}, shinkai_name::ShinkaiName, shinkai_proxy_builder_info::ShinkaiProxyBuilderInfo, shinkai_tool_offering::{ToolPrice, UsageTypeInquiry}, wallet_mixed::AddressBalanceList
+    }, shinkai_message::shinkai_message_schemas::MessageSchemaType, shinkai_utils::{
+        encryption::clone_static_secret_key, shinkai_message_builder::ShinkaiMessageBuilder, signatures::clone_signature_secret_key
+    }
 };
 use shinkai_sqlite::SqliteManager;
 use shinkai_tools_primitives::tools::{
-    network_tool::NetworkTool, parameters::Parameters, shinkai_tool::ShinkaiToolHeader, tool_output_arg::ToolOutputArg,
+    network_tool::NetworkTool, parameters::Parameters, shinkai_tool::ShinkaiToolHeader, tool_output_arg::ToolOutputArg
 };
 use tokio::sync::{Mutex, RwLock};
 use x25519_dalek::StaticSecret as EncryptionStaticKey;
 
 use crate::{
-    managers::{identity_manager::IdentityManagerTrait, tool_router::ToolRouter},
-    network::{
-        network_manager_utils::{get_proxy_builder_info_static, send_message_to_peer},
-        node::ProxyConnectionInfo,
-    },
-    wallet::wallet_manager::WalletManager,
+    managers::{identity_manager::IdentityManagerTrait, tool_router::ToolRouter}, network::{
+        network_manager_utils::{get_proxy_builder_info_static, send_message_to_peer}, node::ProxyConnectionInfo
+    }, wallet::wallet_manager::WalletManager
 };
 
 use super::external_agent_offerings_manager::AgentOfferingManagerError;
@@ -150,7 +140,7 @@ impl MyAgentOfferingsManager {
         if let Some(identity_manager_arc) = self.identity_manager.upgrade() {
             let identity_manager = identity_manager_arc.lock().await;
             let standard_identity = identity_manager
-                .external_profile_to_global_identity(&network_tool.provider.get_node_name_string())
+                .external_profile_to_global_identity(&network_tool.provider.get_node_name_string(), Some(true))
                 .await
                 .map_err(|e| AgentOfferingManagerError::OperationFailed(e))?;
             drop(identity_manager);
@@ -195,7 +185,8 @@ impl MyAgentOfferingsManager {
     ///
     /// # Returns
     ///
-    /// * `Result<bool, AgentOfferingManagerError>` - True if the invoice is valid (and even if we asked for it) false otherwise.
+    /// * `Result<bool, AgentOfferingManagerError>` - True if the invoice is valid (and even if we asked for it) false
+    ///   otherwise.
     pub async fn verify_invoice(&self, invoice: &Invoice) -> Result<bool, AgentOfferingManagerError> {
         // Upgrade the database reference to a strong reference
         let db = self
@@ -493,7 +484,7 @@ impl MyAgentOfferingsManager {
         if let Some(identity_manager_arc) = self.identity_manager.upgrade() {
             let identity_manager = identity_manager_arc.lock().await;
             let standard_identity = identity_manager
-                .external_profile_to_global_identity(&invoice.provider_name.to_string())
+                .external_profile_to_global_identity(&invoice.provider_name.to_string(), None)
                 .await
                 .map_err(|e| AgentOfferingManagerError::OperationFailed(e))?;
             drop(identity_manager);
@@ -651,11 +642,9 @@ mod tests {
     use async_trait::async_trait;
 
     use shinkai_message_primitives::{
-        schemas::identity::{Identity, StandardIdentity, StandardIdentityType},
-        shinkai_message::shinkai_message_schemas::IdentityPermissions,
-        shinkai_utils::{
-            encryption::unsafe_deterministic_encryption_keypair, signatures::unsafe_deterministic_signature_keypair,
-        },
+        schemas::identity::{Identity, StandardIdentity, StandardIdentityType}, shinkai_message::shinkai_message_schemas::IdentityPermissions, shinkai_utils::{
+            encryption::unsafe_deterministic_encryption_keypair, signatures::unsafe_deterministic_signature_keypair
+        }
     };
 
     use std::{fs, path::Path};
@@ -712,6 +701,7 @@ mod tests {
         async fn external_profile_to_global_identity(
             &self,
             full_profile_name: &str,
+            _: Option<bool>,
         ) -> Result<StandardIdentity, String> {
             if full_profile_name == "@@localhost.sep-shinkai" {
                 if let Identity::Standard(identity) = &self.dummy_standard_identity {

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -2999,15 +2999,19 @@ impl Node {
             NodeCommand::V2ApiComputeQuestsStatus { bearer, res } => {
                 let db_clone = Arc::clone(&self.db);
                 let node_name_clone = self.node_name.clone();
+                let encryption_public_key_clone = self.encryption_public_key.clone();
+                let identity_public_key_clone = self.identity_public_key.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_compute_quests_status(db_clone, node_name_clone, bearer, res).await;
+                    let _ = Node::v2_api_compute_quests_status(db_clone, node_name_clone, encryption_public_key_clone, identity_public_key_clone, bearer, res).await;
                 });
             }
             NodeCommand::V2ApiComputeAndSendQuestsStatus { bearer, res } => {
                 let db_clone = Arc::clone(&self.db);
                 let node_name_clone = self.node_name.clone();
+                let encryption_public_key_clone = self.encryption_public_key.clone();
+                let identity_public_key_clone = self.identity_public_key.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_compute_and_send_quests_status(db_clone, node_name_clone, bearer, res).await;
+                    let _ = Node::v2_api_compute_and_send_quests_status(db_clone, node_name_clone, encryption_public_key_clone, identity_public_key_clone, bearer, res).await;
                 });
             }
             _ => (),

--- a/shinkai-bin/shinkai-node/src/network/network_manager/network_job_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/network_manager/network_job_manager.rs
@@ -32,7 +32,7 @@ use tokio::sync::{Mutex, Semaphore};
 use x25519_dalek::StaticSecret as EncryptionStaticKey;
 
 use super::network_handlers::{
-    extract_message, handle_based_on_message_content_and_encryption, verify_message_signature,
+    extract_message, handle_based_on_message_content_and_encryption, verify_message_signature
 };
 use super::network_job_manager_error::NetworkJobQueueError;
 
@@ -486,7 +486,7 @@ impl NetworkJobManager {
         let sender_identity = identity_manager
             .lock()
             .await
-            .external_profile_to_global_identity(&sender_profile_name_string)
+            .external_profile_to_global_identity(&sender_profile_name_string, None)
             .await;
 
         if let Err(e) = sender_identity {

--- a/shinkai-bin/shinkai-node/src/network/network_manager_utils.rs
+++ b/shinkai-bin/shinkai-node/src/network/network_manager_utils.rs
@@ -1,9 +1,7 @@
 use std::sync::{Arc, Weak};
 
 use shinkai_message_primitives::{
-    schemas::{identity::StandardIdentity, shinkai_proxy_builder_info::ShinkaiProxyBuilderInfo},
-    shinkai_message::shinkai_message::ShinkaiMessage,
-    shinkai_utils::shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption},
+    schemas::{identity::StandardIdentity, shinkai_proxy_builder_info::ShinkaiProxyBuilderInfo}, shinkai_message::shinkai_message::ShinkaiMessage, shinkai_utils::shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption}
 };
 use shinkai_sqlite::SqliteManager;
 use tokio::sync::{Mutex, RwLock};
@@ -11,8 +9,7 @@ use tokio::sync::{Mutex, RwLock};
 use crate::managers::identity_manager::IdentityManagerTrait;
 
 use super::{
-    agent_payments_manager::external_agent_offerings_manager::AgentOfferingManagerError, node::ProxyConnectionInfo,
-    Node,
+    agent_payments_manager::external_agent_offerings_manager::AgentOfferingManagerError, node::ProxyConnectionInfo, Node
 };
 use x25519_dalek::StaticSecret as EncryptionStaticKey;
 
@@ -29,7 +26,10 @@ pub async fn get_proxy_builder_info_static(
     let proxy_connection_info = proxy_connection_info.lock().await;
     if let Some(proxy_connection) = proxy_connection_info.as_ref() {
         let proxy_name = proxy_connection.proxy_identity.clone().get_node_name_string();
-        match identity_manager.external_profile_to_global_identity(&proxy_name).await {
+        match identity_manager
+            .external_profile_to_global_identity(&proxy_name, None)
+            .await
+        {
             Ok(proxy_identity) => Some(ShinkaiProxyBuilderInfo {
                 proxy_enc_public_key: proxy_identity.node_encryption_public_key,
             }),

--- a/shinkai-bin/shinkai-node/src/network/node.rs
+++ b/shinkai-bin/shinkai-node/src/network/node.rs
@@ -980,7 +980,7 @@ impl Node {
     ) -> Result<SocketAddr, String> {
         let identity_manager = identity_manager.lock().await;
         match identity_manager
-            .external_profile_to_global_identity(proxy_identity)
+            .external_profile_to_global_identity(proxy_identity, None)
             .await
         {
             Ok(identity) => {
@@ -1299,7 +1299,7 @@ impl Node {
             let sender_encryption_pk = maybe_identity_manager
                 .lock()
                 .await
-                .external_profile_to_global_identity(&counterpart_identity.clone())
+                .external_profile_to_global_identity(&counterpart_identity.clone(), None)
                 .await
                 .unwrap()
                 .node_encryption_public_key;

--- a/shinkai-bin/shinkai-node/src/network/v1_api/api_v1_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v1_api/api_v1_commands.rs
@@ -1,12 +1,9 @@
 use crate::managers::identity_manager::IdentityManagerTrait;
 use crate::managers::tool_router::ToolRouter;
 use crate::{
-    llm_provider::job_manager::JobManager,
-    managers::IdentityManager,
-    network::{
-        node::ProxyConnectionInfo, node_error::NodeError, node_shareable_logic::validate_message_main_logic, Node,
-    },
-    utils::update_global_identity::update_global_identity_name,
+    llm_provider::job_manager::JobManager, managers::IdentityManager, network::{
+        node::ProxyConnectionInfo, node_error::NodeError, node_shareable_logic::validate_message_main_logic, Node
+    }, utils::update_global_identity::update_global_identity_name
 };
 use aes_gcm::aead::{generic_array::GenericArray, Aead};
 use aes_gcm::Aes256Gcm;
@@ -23,32 +20,23 @@ use shinkai_embedding::model_type::EmbeddingModelType;
 use shinkai_http_api::api_v1::api_v1_handlers::APIUseRegistrationCodeSuccessResponse;
 use shinkai_http_api::node_api_router::{APIError, SendResponseBodyData};
 use shinkai_message_primitives::schemas::identity::{
-    DeviceIdentity, Identity, IdentityType, RegistrationCode, StandardIdentity, StandardIdentityType,
+    DeviceIdentity, Identity, IdentityType, RegistrationCode, StandardIdentity, StandardIdentityType
 };
 use shinkai_message_primitives::schemas::inbox_permission::InboxPermission;
 use shinkai_message_primitives::schemas::smart_inbox::SmartInbox;
 use shinkai_message_primitives::schemas::ws_types::WSUpdateHandler;
 use shinkai_message_primitives::{
     schemas::{
-        inbox_name::InboxName,
-        llm_providers::serialized_llm_provider::SerializedLLMProvider,
-        shinkai_name::{ShinkaiName, ShinkaiSubidentityType},
-    },
-    shinkai_message::{
-        shinkai_message::{MessageBody, MessageData, ShinkaiMessage},
-        shinkai_message_schemas::{
-            APIAddAgentRequest, APIAddOllamaModels, APIChangeJobAgentRequest, APIGetMessagesFromInboxRequest,
-            APIReadUpToTimeRequest, IdentityPermissions, MessageSchemaType, RegistrationCodeRequest,
-            RegistrationCodeType,
-        },
-    },
-    shinkai_utils::{
+        inbox_name::InboxName, llm_providers::serialized_llm_provider::SerializedLLMProvider, shinkai_name::{ShinkaiName, ShinkaiSubidentityType}
+    }, shinkai_message::{
+        shinkai_message::{MessageBody, MessageData, ShinkaiMessage}, shinkai_message_schemas::{
+            APIAddAgentRequest, APIAddOllamaModels, APIChangeJobAgentRequest, APIGetMessagesFromInboxRequest, APIReadUpToTimeRequest, IdentityPermissions, MessageSchemaType, RegistrationCodeRequest, RegistrationCodeType
+        }
+    }, shinkai_utils::{
         encryption::{
-            clone_static_secret_key, encryption_public_key_to_string, string_to_encryption_public_key, EncryptionMethod,
-        },
-        shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption},
-        signatures::{clone_signature_secret_key, signature_public_key_to_string, string_to_signature_public_key},
-    },
+            clone_static_secret_key, encryption_public_key_to_string, string_to_encryption_public_key, EncryptionMethod
+        }, shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption}, signatures::{clone_signature_secret_key, signature_public_key_to_string, string_to_signature_public_key}
+    }
 };
 use shinkai_sqlite::errors::SqliteManagerError;
 use shinkai_sqlite::SqliteManager;
@@ -617,7 +605,7 @@ impl Node {
     #[allow(clippy::too_many_arguments)]
     pub async fn api_handle_registration_code_usage(
         db: Arc<SqliteManager>,
-        
+
         node_name: ShinkaiName,
         encryption_secret_key: EncryptionStaticKey,
         first_device_needs_registration_code: bool,
@@ -861,7 +849,8 @@ impl Node {
                         let signature_pk_obj = string_to_signature_public_key(profile_identity_pk.as_str()).unwrap();
                         let encryption_pk_obj =
                             string_to_encryption_public_key(profile_encryption_pk.as_str()).unwrap();
-                        // let full_identity_name = format!("{}/{}", self.node_profile_name.clone(), profile_name.clone());
+                        // let full_identity_name = format!("{}/{}", self.node_profile_name.clone(),
+                        // profile_name.clone());
 
                         let full_identity_name_result = ShinkaiName::from_node_and_profile_names(
                             node_name.get_node_name_string(),
@@ -989,7 +978,8 @@ impl Node {
                         }
 
                         // Logic for handling device identity
-                        // let full_identity_name = format!("{}/{}", self.node_profile_name.clone(), profile_name.clone());
+                        // let full_identity_name = format!("{}/{}", self.node_profile_name.clone(),
+                        // profile_name.clone());
                         let full_identity_name = ShinkaiName::from_node_and_profile_names_and_type_and_name(
                             node_name.get_node_name_string(),
                             profile_name,
@@ -1891,7 +1881,8 @@ impl Node {
             }
         };
 
-        // Convert DeviceIdentity to StandardIdentity if necessary and check if it's a Profile type with admin privileges
+        // Convert DeviceIdentity to StandardIdentity if necessary and check if it's a Profile type with admin
+        // privileges
         let standard_identity = match sender_identity {
             Identity::Standard(std_identity) => Some(std_identity),
             Identity::Device(device_identity) => device_identity.to_standard_identity(),
@@ -3017,7 +3008,7 @@ impl Node {
             // Check if the new node name exists in the blockchain and the keys match
             let identity_manager = identity_manager.lock().await;
             match identity_manager
-                .external_profile_to_global_identity(new_node_name.get_node_name_string().as_str())
+                .external_profile_to_global_identity(new_node_name.get_node_name_string().as_str(), Some(true))
                 .await
             {
                 Ok(standard_identity) => {
@@ -3196,7 +3187,7 @@ impl Node {
         let external_global_identity_result = identity_manager
             .lock()
             .await
-            .external_profile_to_global_identity(&recipient_node_name_string.clone())
+            .external_profile_to_global_identity(&recipient_node_name_string.clone(), None)
             .await;
 
         let external_global_identity = match external_global_identity_result {

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
@@ -15,21 +15,33 @@ use reqwest::StatusCode;
 
 use shinkai_embedding::{embedding_generator::RemoteEmbeddingGenerator, model_type::EmbeddingModelType};
 use shinkai_http_api::{
-    api_v1::api_v1_handlers::APIUseRegistrationCodeSuccessResponse, api_v2::api_v2_handlers_general::InitialRegistrationRequest, node_api_router::{APIError, GetPublicKeysResponse}
+    api_v1::api_v1_handlers::APIUseRegistrationCodeSuccessResponse,
+    api_v2::api_v2_handlers_general::InitialRegistrationRequest,
+    node_api_router::{APIError, GetPublicKeysResponse},
 };
 use shinkai_message_primitives::{
-    schemas::ws_types::WSUpdateHandler, shinkai_message::shinkai_message_schemas::JobCreationInfo, shinkai_utils::{job_scope::MinimalJobScope, shinkai_time::ShinkaiStringTime}
+    schemas::ws_types::WSUpdateHandler,
+    shinkai_message::shinkai_message_schemas::JobCreationInfo,
+    shinkai_utils::{job_scope::MinimalJobScope, shinkai_time::ShinkaiStringTime},
 };
 use shinkai_message_primitives::{
     schemas::{
-        identity::{Identity, IdentityType, RegistrationCode}, inbox_name::InboxName, llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider}, shinkai_name::ShinkaiName
-    }, shinkai_message::{
-        shinkai_message::{MessageBody, MessageData, ShinkaiMessage}, shinkai_message_schemas::{
-            APIAddOllamaModels, IdentityPermissions, JobMessage, MessageSchemaType, V2ChatMessage
-        }
-    }, shinkai_utils::{
-        encryption::{encryption_public_key_to_string, EncryptionMethod}, shinkai_message_builder::ShinkaiMessageBuilder, signatures::signature_public_key_to_string
-    }
+        identity::{Identity, IdentityType, RegistrationCode},
+        inbox_name::InboxName,
+        llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider},
+        shinkai_name::ShinkaiName,
+    },
+    shinkai_message::{
+        shinkai_message::{MessageBody, MessageData, ShinkaiMessage},
+        shinkai_message_schemas::{
+            APIAddOllamaModels, IdentityPermissions, JobMessage, MessageSchemaType, V2ChatMessage,
+        },
+    },
+    shinkai_utils::{
+        encryption::{encryption_public_key_to_string, EncryptionMethod},
+        shinkai_message_builder::ShinkaiMessageBuilder,
+        signatures::signature_public_key_to_string,
+    },
 };
 use shinkai_sqlite::SqliteManager;
 use tokio::sync::Mutex;
@@ -38,7 +50,11 @@ use x25519_dalek::PublicKey as EncryptionPublicKey;
 use crate::managers::galxe_quests::{compute_quests, generate_proof};
 use crate::managers::tool_router::ToolRouter;
 use crate::{
-    llm_provider::{job_manager::JobManager, llm_stopper::LLMStopper}, managers::{identity_manager::IdentityManagerTrait, IdentityManager}, network::{node_error::NodeError, node_shareable_logic::download_zip_file, Node}, tools::tool_generation, utils::update_global_identity::update_global_identity_name
+    llm_provider::{job_manager::JobManager, llm_stopper::LLMStopper},
+    managers::{identity_manager::IdentityManagerTrait, IdentityManager},
+    network::{node_error::NodeError, node_shareable_logic::download_zip_file, Node},
+    tools::tool_generation,
+    utils::update_global_identity::update_global_identity_name,
 };
 
 use shinkai_message_primitives::schemas::shinkai_preferences::ShinkaiInternalComms;
@@ -1758,8 +1774,19 @@ impl Node {
         Ok(())
     }
 
-    async fn internal_compute_quests_status(db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<Value, String> {
-        let quests_status = compute_quests(db.clone(), node_name.clone()).await?;
+    async fn internal_compute_quests_status(
+        db: Arc<SqliteManager>,
+        node_name: ShinkaiName,
+        encryption_public_key: EncryptionPublicKey,
+        identity_public_key: VerifyingKey,
+    ) -> Result<Value, String> {
+        let quests_status = compute_quests(
+            db.clone(),
+            node_name.clone(),
+            encryption_public_key.clone(),
+            identity_public_key.clone(),
+        )
+        .await?;
 
         // Convert the Vec into a Vec of objects with just name and status
         let quests_array: Vec<_> = quests_status
@@ -1806,6 +1833,8 @@ impl Node {
     pub async fn v2_api_compute_quests_status(
         db: Arc<SqliteManager>,
         node_name: ShinkaiName,
+        encryption_public_key: EncryptionPublicKey,
+        identity_public_key: VerifyingKey,
         bearer: String,
         res: Sender<Result<Value, APIError>>,
     ) -> Result<(), NodeError> {
@@ -1813,7 +1842,7 @@ impl Node {
             return Ok(());
         }
 
-        match Self::internal_compute_quests_status(db, node_name).await {
+        match Self::internal_compute_quests_status(db, node_name, encryption_public_key, identity_public_key).await {
             Ok(response) => {
                 let _ = res.send(Ok(response)).await;
             }
@@ -1833,6 +1862,8 @@ impl Node {
     pub async fn v2_api_compute_and_send_quests_status(
         db: Arc<SqliteManager>,
         node_name: ShinkaiName,
+        encryption_public_key: EncryptionPublicKey,
+        identity_public_key: VerifyingKey,
         bearer: String,
         res: Sender<Result<Value, APIError>>,
     ) -> Result<(), NodeError> {
@@ -1840,7 +1871,14 @@ impl Node {
             return Ok(());
         }
 
-        match Self::internal_compute_quests_status(db.clone(), node_name.clone()).await {
+        match Self::internal_compute_quests_status(
+            db.clone(),
+            node_name.clone(),
+            encryption_public_key.clone(),
+            identity_public_key.clone(),
+        )
+        .await
+        {
             Ok(response) => {
                 // Use the production Galxe API endpoint
                 let galxe_quests_url = std::env::var("GALXE_QUESTS_URL")

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
@@ -15,33 +15,21 @@ use reqwest::StatusCode;
 
 use shinkai_embedding::{embedding_generator::RemoteEmbeddingGenerator, model_type::EmbeddingModelType};
 use shinkai_http_api::{
-    api_v1::api_v1_handlers::APIUseRegistrationCodeSuccessResponse,
-    api_v2::api_v2_handlers_general::InitialRegistrationRequest,
-    node_api_router::{APIError, GetPublicKeysResponse},
+    api_v1::api_v1_handlers::APIUseRegistrationCodeSuccessResponse, api_v2::api_v2_handlers_general::InitialRegistrationRequest, node_api_router::{APIError, GetPublicKeysResponse}
 };
 use shinkai_message_primitives::{
-    schemas::ws_types::WSUpdateHandler,
-    shinkai_message::shinkai_message_schemas::JobCreationInfo,
-    shinkai_utils::{job_scope::MinimalJobScope, shinkai_time::ShinkaiStringTime},
+    schemas::ws_types::WSUpdateHandler, shinkai_message::shinkai_message_schemas::JobCreationInfo, shinkai_utils::{job_scope::MinimalJobScope, shinkai_time::ShinkaiStringTime}
 };
 use shinkai_message_primitives::{
     schemas::{
-        identity::{Identity, IdentityType, RegistrationCode},
-        inbox_name::InboxName,
-        llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider},
-        shinkai_name::ShinkaiName,
-    },
-    shinkai_message::{
-        shinkai_message::{MessageBody, MessageData, ShinkaiMessage},
-        shinkai_message_schemas::{
-            APIAddOllamaModels, IdentityPermissions, JobMessage, MessageSchemaType, V2ChatMessage,
-        },
-    },
-    shinkai_utils::{
-        encryption::{encryption_public_key_to_string, EncryptionMethod},
-        shinkai_message_builder::ShinkaiMessageBuilder,
-        signatures::signature_public_key_to_string,
-    },
+        identity::{Identity, IdentityType, RegistrationCode}, inbox_name::InboxName, llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider}, shinkai_name::ShinkaiName
+    }, shinkai_message::{
+        shinkai_message::{MessageBody, MessageData, ShinkaiMessage}, shinkai_message_schemas::{
+            APIAddOllamaModels, IdentityPermissions, JobMessage, MessageSchemaType, V2ChatMessage
+        }
+    }, shinkai_utils::{
+        encryption::{encryption_public_key_to_string, EncryptionMethod}, shinkai_message_builder::ShinkaiMessageBuilder, signatures::signature_public_key_to_string
+    }
 };
 use shinkai_sqlite::SqliteManager;
 use tokio::sync::Mutex;
@@ -50,11 +38,7 @@ use x25519_dalek::PublicKey as EncryptionPublicKey;
 use crate::managers::galxe_quests::{compute_quests, generate_proof};
 use crate::managers::tool_router::ToolRouter;
 use crate::{
-    llm_provider::{job_manager::JobManager, llm_stopper::LLMStopper},
-    managers::{identity_manager::IdentityManagerTrait, IdentityManager},
-    network::{node_error::NodeError, node_shareable_logic::download_zip_file, Node},
-    tools::tool_generation,
-    utils::update_global_identity::update_global_identity_name,
+    llm_provider::{job_manager::JobManager, llm_stopper::LLMStopper}, managers::{identity_manager::IdentityManagerTrait, IdentityManager}, network::{node_error::NodeError, node_shareable_logic::download_zip_file, Node}, tools::tool_generation, utils::update_global_identity::update_global_identity_name
 };
 
 use shinkai_message_primitives::schemas::shinkai_preferences::ShinkaiInternalComms;
@@ -621,7 +605,7 @@ impl Node {
             // Check if the new node name exists in the blockchain and the keys match
             let identity_manager = identity_manager.lock().await;
             match identity_manager
-                .external_profile_to_global_identity(new_node_name.get_node_name_string().as_str())
+                .external_profile_to_global_identity(new_node_name.get_node_name_string().as_str(), Some(true))
                 .await
             {
                 Ok(standard_identity) => {

--- a/shinkai-bin/shinkai-node/tests/it/get_onchain_identity_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/get_onchain_identity_tests.rs
@@ -20,7 +20,7 @@ mod tests {
 
             let identity = "node1_test.sep-shinkai".to_string();
 
-            let record = registry.get_identity_record(identity.clone()).await.unwrap();
+            let record = registry.get_identity_record(identity.clone(), None).await.unwrap();
 
             let expected_record = OnchainIdentity {
                 shinkai_identity: "node1_test.sep-shinkai".to_string(),

--- a/shinkai-bin/shinkai-node/tests/it/websocket_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/websocket_tests.rs
@@ -93,7 +93,11 @@ impl IdentityManagerTrait for MockIdentityManager {
         Box::new(self.clone())
     }
 
-    async fn external_profile_to_global_identity(&self, _full_profile_name: &str) -> Result<StandardIdentity, String> {
+    async fn external_profile_to_global_identity(
+        &self,
+        _full_profile_name: &str,
+        _: Option<bool>,
+    ) -> Result<StandardIdentity, String> {
         unimplemented!()
     }
 }
@@ -656,8 +660,8 @@ async fn test_websocket_smart_inbox() {
     std::mem::drop(shinkai_db);
 }
 
-// Note: We need to mock up JobManager and change the depencency of SheetManager to a trait so we can swap between JobManager or the MockJobManager
-// #[tokio::test]
+// Note: We need to mock up JobManager and change the depencency of SheetManager to a trait so we can swap between
+// JobManager or the MockJobManager #[tokio::test]
 // async fn test_websocket_sheet_update() {
 //
 //     // Setup
@@ -835,8 +839,8 @@ async fn test_websocket_smart_inbox() {
 //         .expect("Failed to read message");
 
 //     let encrypted_message = msg.to_text().unwrap();
-//     let decrypted_message = decrypt_message(encrypted_message, &shared_enc_string).expect("Failed to decrypt message");
-//     let ws_message_payload: WSMessagePayload =
+//     let decrypted_message = decrypt_message(encrypted_message, &shared_enc_string).expect("Failed to decrypt
+// message");     let ws_message_payload: WSMessagePayload =
 //         serde_json::from_str(&decrypted_message).expect("Failed to parse WSMessagePayload");
 //     let recovered_shinkai = ShinkaiMessage::from_string(ws_message_payload.message.unwrap()).unwrap();
 //     let recovered_content = recovered_shinkai.get_message_content().unwrap();

--- a/shinkai-libs/shinkai-tcp-relayer/src/tcp_server.rs
+++ b/shinkai-libs/shinkai-tcp-relayer/src/tcp_server.rs
@@ -110,7 +110,7 @@ impl TCPProxy {
         );
 
         // Fetch the public keys from the registry
-        let registry_identity = registry.get_identity_record(node_name.to_string()).await.unwrap();
+        let registry_identity = registry.get_identity_record(node_name.to_string(), None).await.unwrap();
         eprintln!("Registry Identity: {:?}", registry_identity);
         let registry_identity_public_key = registry_identity.signature_verifying_key().unwrap();
         let registry_encryption_public_key = registry_identity.encryption_public_key().unwrap();
@@ -531,7 +531,7 @@ impl TCPProxy {
 
         let recipient_addresses = if !recipient_matches {
             // Fetch the public keys from the registry
-            let registry_identity = registry.get_identity_record(msg_recipient.clone()).await.unwrap();
+            let registry_identity = registry.get_identity_record(msg_recipient.clone(), None).await.unwrap();
             registry_identity.address_or_proxy_nodes
         } else {
             vec![]
@@ -600,7 +600,7 @@ impl TCPProxy {
         let relayer_addresses = if !recipient_matches {
             // Fetch the public keys from the registry
             let registry_identity = registry
-                .get_identity_record(tcp_node_name_string.clone())
+                .get_identity_record(tcp_node_name_string.clone(), None)
                 .await
                 .unwrap();
             registry_identity.address_or_proxy_nodes
@@ -640,7 +640,7 @@ impl TCPProxy {
         session_id: Uuid,
     ) -> Result<(), NetworkMessageError> {
         // Fetch the public keys from the registry
-        let registry_identity = registry.get_identity_record(msg_sender.clone()).await.unwrap();
+        let registry_identity = registry.get_identity_record(msg_sender.clone(), None).await.unwrap();
         let sender_encryption_pk = registry_identity.encryption_public_key()?;
         let sender_signature_pk = registry_identity.signature_verifying_key()?;
 
@@ -731,7 +731,7 @@ impl TCPProxy {
         writer: Arc<Mutex<WriteHalf<TcpStream>>>,
         session_id: Uuid,
     ) -> Result<(), NetworkMessageError> {
-        match registry.get_identity_record(msg_recipient.clone()).await {
+        match registry.get_identity_record(msg_recipient.clone(), None).await {
             Ok(onchain_identity) => {
                 match onchain_identity.first_address().await {
                     Ok(first_address) => {
@@ -949,7 +949,7 @@ impl TCPProxy {
         let signature = Self::read_signature_from_cursor(&mut cursor).await?;
 
         // eprintln!("Received response: {}", signature);
-        let onchain_identity = self.registry.get_identity_record(identity.to_string()).await;
+        let onchain_identity = self.registry.get_identity_record(identity.to_string(), None).await;
         let public_key = onchain_identity.unwrap().signature_verifying_key().unwrap();
 
         if public_key.verify(validation_data.as_bytes(), &signature).is_err() {

--- a/shinkai-libs/shinkai-tcp-relayer/tests/server_tests.rs
+++ b/shinkai-libs/shinkai-tcp-relayer/tests/server_tests.rs
@@ -570,7 +570,7 @@ async fn get_onchain_identity(node_name: &str) -> (VerifyingKey, EncryptionPubli
     let registry = ShinkaiRegistry::new(&rpc_url, &contract_address, None).await.unwrap();
 
     // Fetch the public keys from the registry
-    let registry_identity = registry.get_identity_record(node_name.to_string()).await.unwrap();
+    let registry_identity = registry.get_identity_record(node_name.to_string(), None).await.unwrap();
     eprintln!("Registry Identity: {:?}", registry_identity);
     let registry_identity_public_key = registry_identity.signature_verifying_key().unwrap();
     let registry_encryption_public_key = registry_identity.encryption_public_key().unwrap();


### PR DESCRIPTION
# Fix identity created quest

Now we get node_name, encryption public key and identity public key from the in memory node info (previously it was used the DB which is not maintained)

Bump to v0.9.10