### PR TITLE
Add V2 API endpoint for retrieving node storage location

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -2109,6 +2109,12 @@ impl Node {
                     let _ = Node::v2_api_list_wallets(db_clone, wallet_manager_clone, bearer, res).await;
                 });
             }
+            NodeCommand::V2ApiGetStorageLocation { bearer, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_get_storage_location(db_clone, bearer, res).await;
+                });
+            }
             NodeCommand::V2ApiRequestInvoice {
                 bearer,
                 tool_key_name,

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{File, canonicalize};
 use std::io::Write;
 use std::{env, sync::Arc};
 use std::path::PathBuf;
@@ -296,13 +296,8 @@ impl Node {
             Some(val) => Some(val),
             None => Some("storage".to_string()),
         };
-        let base_path = env::current_exe().unwrap().parent().unwrap().to_path_buf();
-        let storage_location = base_path
-            .join(node_storage_path.unwrap_or_default())
-            .join("filesystem")
-            .to_string_lossy()
-            .to_string();
-        let _ = res.send(Ok(storage_location)).await;
+        let base_path = tokio::fs::canonicalize(node_storage_path.as_ref().unwrap()).await.unwrap();
+        let _ = res.send(Ok(base_path.to_string_lossy().to_string())).await;
 
         Ok(())
     }

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
@@ -292,10 +292,13 @@ impl Node {
         if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
             return Ok(());
         }
-        let node_storage_path: String = env::var("NODE_STORAGE_PATH").unwrap_or_else(|_| "storage".to_string());
+        let node_storage_path: Option<String> = match env::var("NODE_STORAGE_PATH").ok() {
+            Some(val) => Some(val),
+            None => Some("storage".to_string()),
+        };
         let base_path = env::current_exe().unwrap().parent().unwrap().to_path_buf();
         let storage_location = base_path
-            .join(node_storage_path)
+            .join(node_storage_path.unwrap_or_default())
             .join("filesystem")
             .to_string_lossy()
             .to_string();

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_general.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_general.rs
@@ -49,6 +49,12 @@ pub fn general_routes(
         .and(warp::body::json())
         .and_then(initial_registration_handler);
 
+    let get_storage_location_route = warp::path("storage_location")
+        .and(warp::get())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and_then(get_storage_location_handler);
+
     let get_default_embedding_model_route = warp::path("default_embedding_model")
         .and(warp::get())
         .and(with_sender(node_commands_sender.clone()))
@@ -206,6 +212,7 @@ pub fn general_routes(
     public_keys_route
         .or(health_check_route)
         .or(initial_registration_route)
+        .or(get_storage_location_route)
         .or(get_default_embedding_model_route)
         .or(get_supported_embedding_models_route)
         .or(update_default_embedding_model_route)
@@ -329,6 +336,36 @@ pub async fn initial_registration_handler(
             warp::reply::json(&error),
             StatusCode::from_u16(error.code).unwrap(),
         )),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v2/storage_location",
+    responses(
+        (status = 200, description = "Successfully retrieved storage location", body = String),
+        (status = 500, description = "Internal server error", body = APIError),
+    )
+)]
+pub async fn get_storage_location_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiGetStorageLocation {
+            bearer,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => Ok(warp::reply::json(&response)),
+        Err(error) => Err(warp::reject::custom(error)),
     }
 }
 

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_general.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_general.rs
@@ -364,7 +364,7 @@ pub async fn get_storage_location_handler(
     let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
 
     match result {
-        Ok(response) => Ok(warp::reply::json(&response)),
+        Ok(response) => Ok(warp::reply::json(&json!({ "storage_location": response }))),
         Err(error) => Err(warp::reject::custom(error)),
     }
 }

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -780,6 +780,10 @@ pub enum NodeCommand {
     V2ApiHealthCheck {
         res: Sender<Result<serde_json::Value, APIError>>,
     },
+    V2ApiGetStorageLocation {
+        bearer: String,
+        res: Sender<Result<String, APIError>>,
+    },
     V2ApiScanOllamaModels {
         bearer: String,
         res: Sender<Result<Vec<serde_json::Value>, APIError>>,


### PR DESCRIPTION
Implement a new API endpoint to fetch the node's storage location, including:
- New NodeCommand variant for storage location retrieval
- Handler for the /v2/storage_location GET route
- Implementation of v2_api_get_storage_location method in Node