### PR TITLE
Implement endpoint to get user quotas and improvements to inference b…

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/shinkai_backend.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/shinkai_backend.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::sync::Arc;
 
 use crate::llm_provider::execution::chains::inference_chain_trait::LLMInferenceResponse;
@@ -6,6 +7,7 @@ use crate::managers::galxe_quests::generate_proof;
 use crate::managers::model_capabilities_manager::{ModelCapabilitiesManager, PromptResultEnum};
 use rusqlite::params;
 use shinkai_message_primitives::schemas::job_config::JobConfig;
+use shinkai_message_primitives::schemas::llm_providers::shinkai_backend::QuotaResponse;
 use shinkai_message_primitives::schemas::prompts::Prompt;
 use shinkai_message_primitives::schemas::ws_types::WSUpdateHandler;
 use shinkai_sqlite::SqliteManager;
@@ -44,140 +46,243 @@ impl LLMService for ShinkaiBackend {
         _db: Arc<SqliteManager>,
     ) -> Result<LLMInferenceResponse, LLMProviderError> {
         let session_id = Uuid::new_v4().to_string();
+
+        let api_url: String;
         if let Some(base_url) = url {
-            let url = format!("{}/ai/chat/completions", base_url);
-            if let Some(key) = api_key {
-                let result = openai_prepare_messages(&model, prompt)?;
-                let messages_json = match self.model_type().to_uppercase().as_str() {
-                    "PREMIUM_TEXT_INFERENCE" | "STANDARD_TEXT_INFERENCE" | "FREE_TEXT_INFERENCE" => {
-                        match result.messages {
-                            PromptResultEnum::Value(v) => v,
-                            _ => {
-                                return Err(LLMProviderError::UnexpectedPromptResultVariant(
-                                    "Expected Value variant in PromptResultEnum".to_string(),
-                                ))
-                            }
-                        }
-                    }
-                    _ => {
-                        return Err(LLMProviderError::InvalidModelType(format!(
-                            "Unsupported model type: {:?}",
-                            self.model_type()
-                        )))
-                    }
-                };
-
-                let is_stream = config.as_ref().and_then(|c| c.stream).unwrap_or(true);
-
-                // Extract tools_json from the result
-                let tools_json = result.functions.unwrap_or_else(Vec::new);
-
-                // Print messages_json as a pretty JSON string
-                match serde_json::to_string_pretty(&messages_json) {
-                    Ok(pretty_json) => eprintln!("Messages JSON: {}", pretty_json),
-                    Err(e) => eprintln!("Failed to serialize messages_json: {:?}", e),
-                };
-
-                match serde_json::to_string_pretty(&tools_json) {
-                    Ok(pretty_json) => eprintln!("Tools JSON: {}", pretty_json),
-                    Err(e) => eprintln!("Failed to serialize tools_json: {:?}", e),
-                };
-
-                // Get the node's signature public key from the database
-                let (node_name, node_signature_public_key) = _db
-                    .query_row(
-                        "SELECT node_name, node_signature_public_key FROM local_node_keys LIMIT 1",
-                        params![],
-                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)), 
-                    )
-                    .map_err(|e| format!("Failed to get node signature public key: {}", e))?;
-
-                // Generate proof using the node's signature public key
-                let empty_json = json!({});
-                let last_message = messages_json.as_array().and_then(|arr| arr.last()).unwrap_or(&empty_json);
-                let (signature, metadata) = generate_proof(hex::encode(node_signature_public_key), serde_json::to_string(last_message)?)?;
-
-                // Set up initial payload with appropriate token limit field based on model capabilities
-                let mut payload = if ModelCapabilitiesManager::has_reasoning_capabilities(&model) {
-                    json!({
-                        "model": self.model_type,
-                        "messages": messages_json,
-                        "max_completion_tokens": result.remaining_output_tokens,
-                        "stream": is_stream,
-                    })
-                } else {
-                    json!({
-                        "model": self.model_type,
-                        "messages": messages_json,
-                        "max_tokens": result.remaining_output_tokens,
-                        "stream": is_stream,
-                    })
-                };
-
-                let headers = json!({
-                    "x-shinkai-version": env!("CARGO_PKG_VERSION"),
-                    "x-shinkai-identity": node_name,
-                    "x-shinkai-signature": signature,
-                    "x-shinkai-metadata": metadata,
-                });
-
-                // Conditionally add functions to the payload if tools_json is not empty
-                if !tools_json.is_empty() {
-                    payload["functions"] = serde_json::Value::Array(tools_json.clone());
-                }
-
-                // Only add options to payload for non-reasoning models
-                if !ModelCapabilitiesManager::has_reasoning_capabilities(&model) {
-                    add_options_to_payload(&mut payload, config.as_ref());
-                }
-
-                // Print payload as a pretty JSON string
-                match serde_json::to_string_pretty(&payload) {
-                    Ok(pretty_json) => eprintln!("cURL Payload: {}", pretty_json),
-                    Err(e) => eprintln!("Failed to serialize payload: {:?}", e),
-                };
-
-                let mut payload_log = payload.clone();
-                truncate_image_url_in_payload(&mut payload_log);
-                shinkai_log(
-                    ShinkaiLogOption::JobExecution,
-                    ShinkaiLogLevel::Debug,
-                    format!("Call API Body: {:?}", payload_log).as_str(),
-                );
-
-                if is_stream {
-                    handle_streaming_response(
-                        client,
-                        url,
-                        payload,
-                        key.clone(),
-                        inbox_name,
-                        ws_manager_trait,
-                        llm_stopper,
-                        session_id,
-                        Some(tools_json),
-                        Some(headers),
-                    )
-                    .await
-                } else {
-                    handle_non_streaming_response(
-                        client,
-                        url,
-                        payload,
-                        key.clone(),
-                        inbox_name,
-                        llm_stopper,
-                        ws_manager_trait,
-                        Some(tools_json),
-                        Some(headers),
-                    )
-                    .await
-                }
-            } else {
-                Err(LLMProviderError::ApiKeyNotSet)
-            }
+            api_url = format!("{}/ai/chat/completions", base_url);
         } else {
-            Err(LLMProviderError::UrlNotSet)
+            // Get base URL from environment variable or use default
+            let base_url = env::var("SHINKAI_INFERENCE_BASE_URL")
+                .unwrap_or_else(|_| "https://api.shinkai.com/inference".to_string());
+            api_url = format!("{}/ai/chat/completions", base_url);
+        }
+
+        let key: String = api_key.map_or_else(|| "NO_KEY".to_string(), |k| k.clone());
+
+        let result = openai_prepare_messages(&model, prompt)?;
+
+        // Check if model_type is not supported and log a warning
+        if !matches!(
+            self.model_type().to_uppercase().as_str(),
+            "PREMIUM_TEXT_INFERENCE" | "STANDARD_TEXT_INFERENCE" | "FREE_TEXT_INFERENCE"
+        ) {
+            shinkai_log(
+                ShinkaiLogOption::JobExecution,
+                ShinkaiLogLevel::Info,
+                &format!(
+                    "Unsupported model type: {}. Defaulting to FREE_TEXT_INFERENCE",
+                    self.model_type()
+                ),
+            );
+        }
+
+        // Extract messages regardless of model type
+        let messages_json = match result.messages {
+            PromptResultEnum::Value(v) => v,
+            _ => {
+                return Err(LLMProviderError::UnexpectedPromptResultVariant(
+                    "Expected Value variant in PromptResultEnum".to_string(),
+                ))
+            }
+        };
+
+        let is_stream = config.as_ref().and_then(|c| c.stream).unwrap_or(true);
+
+        // Extract tools_json from the result
+        let tools_json = result.functions.unwrap_or_else(Vec::new);
+
+        // Print messages_json as a pretty JSON string
+        match serde_json::to_string_pretty(&messages_json) {
+            Ok(pretty_json) => eprintln!("Messages JSON: {}", pretty_json),
+            Err(e) => eprintln!("Failed to serialize messages_json: {:?}", e),
+        };
+
+        match serde_json::to_string_pretty(&tools_json) {
+            Ok(pretty_json) => eprintln!("Tools JSON: {}", pretty_json),
+            Err(e) => eprintln!("Failed to serialize tools_json: {:?}", e),
+        };
+
+        // Get the node's signature public key from the database
+        let (node_name, node_signature_public_key) = _db
+            .query_row(
+                "SELECT node_name, node_signature_public_key FROM local_node_keys LIMIT 1",
+                params![],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+            )
+            .map_err(|e| format!("Failed to get node signature public key: {}", e))?;
+
+        // Generate proof using the node's signature public key
+        let empty_json = json!({});
+        let last_message = messages_json
+            .as_array()
+            .and_then(|arr| arr.last())
+            .unwrap_or(&empty_json);
+        let (signature, metadata) = generate_proof(
+            hex::encode(node_signature_public_key),
+            serde_json::to_string(last_message)?,
+        )?;
+
+        // Set up initial payload with appropriate token limit field based on model capabilities
+        let model_type_to_use = if matches!(
+            self.model_type().to_uppercase().as_str(),
+            "PREMIUM_TEXT_INFERENCE" | "STANDARD_TEXT_INFERENCE" | "FREE_TEXT_INFERENCE"
+        ) {
+            self.model_type.clone()
+        } else {
+            "FREE_TEXT_INFERENCE".to_string()
+        };
+
+        let mut payload = if ModelCapabilitiesManager::has_reasoning_capabilities(&model) {
+            json!({
+                "model": model_type_to_use,
+                "messages": messages_json,
+                "max_completion_tokens": result.remaining_output_tokens,
+                "stream": is_stream,
+            })
+        } else {
+            json!({
+                "model": model_type_to_use,
+                "messages": messages_json,
+                "max_tokens": result.remaining_output_tokens,
+                "stream": is_stream,
+            })
+        };
+
+        let headers = json!({
+            "x-shinkai-version": env!("CARGO_PKG_VERSION"),
+            "x-shinkai-identity": node_name,
+            "x-shinkai-signature": signature,
+            "x-shinkai-metadata": metadata,
+        });
+
+        // Conditionally add functions to the payload if tools_json is not empty
+        if !tools_json.is_empty() {
+            payload["functions"] = serde_json::Value::Array(tools_json.clone());
+        }
+
+        // Only add options to payload for non-reasoning models
+        if !ModelCapabilitiesManager::has_reasoning_capabilities(&model) {
+            add_options_to_payload(&mut payload, config.as_ref());
+        }
+
+        // Print payload as a pretty JSON string
+        match serde_json::to_string_pretty(&payload) {
+            Ok(pretty_json) => eprintln!("cURL Payload: {}", pretty_json),
+            Err(e) => eprintln!("Failed to serialize payload: {:?}", e),
+        };
+
+        let mut payload_log = payload.clone();
+        truncate_image_url_in_payload(&mut payload_log);
+        shinkai_log(
+            ShinkaiLogOption::JobExecution,
+            ShinkaiLogLevel::Debug,
+            format!("Call API Body: {:?}", payload_log).as_str(),
+        );
+
+        if is_stream {
+            handle_streaming_response(
+                client,
+                api_url,
+                payload,
+                key.clone(),
+                inbox_name,
+                ws_manager_trait,
+                llm_stopper,
+                session_id,
+                Some(tools_json),
+                Some(headers),
+            )
+            .await
+        } else {
+            handle_non_streaming_response(
+                client,
+                api_url,
+                payload,
+                key.clone(),
+                inbox_name,
+                llm_stopper,
+                ws_manager_trait,
+                Some(tools_json),
+                Some(headers),
+            )
+            .await
+        }
+    }
+}
+
+pub async fn check_quota(
+    db: Arc<SqliteManager>,
+    model_type: String,
+) -> Result<QuotaResponse, LLMProviderError> {
+    // Get base URL from environment variable or use default
+    let base_url =
+        env::var("SHINKAI_INFERENCE_BASE_URL").unwrap_or_else(|_| "https://api.shinkai.com/inference".to_string());
+    let api_url = format!("{}/ai/quotas?model={}", base_url, model_type);
+
+    // Get the node's signature public key from the database
+    let (node_name, node_signature_public_key) = db
+        .query_row(
+            "SELECT node_name, node_signature_public_key FROM local_node_keys LIMIT 1",
+            params![],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .map_err(|e| format!("Failed to get node signature public key: {}", e))?;
+
+    // Generate proof using the node's signature public key
+    let (signature, metadata) = generate_proof(
+        hex::encode(node_signature_public_key),
+        json!({
+            "role": "system",
+            "content": "Give me the quota usage for this user."
+        }).to_string(),
+    )?;
+
+    let client = Client::new();
+    match client
+        .get(api_url)
+        .header("x-shinkai-version", env!("CARGO_PKG_VERSION"))
+        .header("x-shinkai-identity", node_name)
+        .header("x-shinkai-signature", signature)
+        .header("x-shinkai-metadata", metadata)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            match response.json::<serde_json::Value>().await {
+                Ok(json_body) => {
+                    // Extract fields from the JSON response
+                    let has_quota = json_body.get("hasQuota").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let tokens_quota = json_body.get("quota").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let used_tokens = json_body.get("usedTokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let reset_time = json_body.get("resetTime").and_then(|v| v.as_u64()).unwrap_or(0);
+
+                    // Create the QuotaResponse object
+                    let quota_response = QuotaResponse {
+                        has_quota,
+                        tokens_quota,
+                        used_tokens,
+                        reset_time,
+                    };
+
+                    Ok(quota_response)
+                }
+                Err(err) => {
+                    shinkai_log(
+                        ShinkaiLogOption::JobExecution,
+                        ShinkaiLogLevel::Error,
+                        format!("Failed to parse response: {:?}", err).as_str(),
+                    );
+                    return Err(LLMProviderError::ReqwestError(err));
+                }
+            }
+        }
+        Err(err) => {
+            shinkai_log(
+                ShinkaiLogOption::JobExecution,
+                ShinkaiLogLevel::Error,
+                format!("Failed to fetch quota: {}", err).as_str(),
+            );
+            return Err(LLMProviderError::ReqwestError(err));
         }
     }
 }

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1873,6 +1873,12 @@ impl Node {
                     .await;
                 });
             }
+            NodeCommand::V2ApiShinkaiBackendGetQuota { bearer, model_type, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_check_shinkai_backend_quota(db_clone, model_type, bearer, res).await;
+                });
+            }
             NodeCommand::V2ApiIsPristine { bearer, res } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -6,7 +6,7 @@ use ed25519_dalek::VerifyingKey;
 use serde_json::{Map, Value};
 use shinkai_message_primitives::{
     schemas::{
-        coinbase_mpc_config::CoinbaseMPCWalletConfig, crontab::{CronTask, CronTaskAction}, custom_prompt::CustomPrompt, identity::{Identity, StandardIdentity}, job_config::JobConfig, llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider}, shinkai_name::ShinkaiName, shinkai_subscription::ShinkaiSubscription, shinkai_tool_offering::{ShinkaiToolOffering, UsageTypeInquiry}, shinkai_tools::{CodeLanguage, DynamicToolType}, smart_inbox::{SmartInbox, V2SmartInbox}, tool_router_key::ToolRouterKey, wallet_complementary::{WalletRole, WalletSource}, wallet_mixed::NetworkIdentifier
+        coinbase_mpc_config::CoinbaseMPCWalletConfig, crontab::{CronTask, CronTaskAction}, custom_prompt::CustomPrompt, identity::{Identity, StandardIdentity}, job_config::JobConfig, llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider, shinkai_backend::QuotaResponse}, shinkai_name::ShinkaiName, shinkai_subscription::ShinkaiSubscription, shinkai_tool_offering::{ShinkaiToolOffering, UsageTypeInquiry}, shinkai_tools::{CodeLanguage, DynamicToolType}, smart_inbox::{SmartInbox, V2SmartInbox}, tool_router_key::ToolRouterKey, wallet_complementary::{WalletRole, WalletSource}, wallet_mixed::NetworkIdentifier
     }, shinkai_message::{
         shinkai_message::ShinkaiMessage, shinkai_message_schemas::{
             APIAddOllamaModels, APIAvailableSharedItems, APIChangeJobAgentRequest, APIExportSheetPayload, APIImportSheetPayload, APISetSheetUploadedFilesPayload, APIVecFsCopyFolder, APIVecFsCopyItem, APIVecFsCreateFolder, APIVecFsDeleteFolder, APIVecFsDeleteItem, APIVecFsMoveFolder, APIVecFsMoveItem, APIVecFsRetrievePathSimplifiedJson, APIVecFsRetrieveSourceFile, APIVecFsSearchItems, ExportInboxMessagesFormat, IdentityPermissions, JobCreationInfo, JobMessage, RegistrationCodeType, V2ChatMessage
@@ -746,6 +746,11 @@ pub enum NodeCommand {
         bearer: String,
         new_name: String,
         res: Sender<Result<(), APIError>>,
+    },
+    V2ApiShinkaiBackendGetQuota {
+        bearer: String,
+        model_type: String,
+        res: Sender<Result<QuotaResponse, APIError>>,
     },
     V2ApiIsPristine {
         bearer: String,

--- a/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/mod.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/mod.rs
@@ -1,3 +1,4 @@
 pub mod serialized_llm_provider;
 pub mod agent;
 pub mod common_agent_llm_provider;
+pub mod shinkai_backend;

--- a/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/shinkai_backend.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/shinkai_backend.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct QuotaResponse {
+    pub has_quota: bool,
+    pub tokens_quota: u64,
+    pub used_tokens: u64,
+    pub reset_time: u64,
+}


### PR DESCRIPTION
…ackend.

- Get user quotas endpoint /v2/shinkai_backend_quota
- Not neccesary to configure model or API key, API url or model to use Shinkai Backend.
- Environment variable `SHINKAI_INFERENCE_BASE_URL` to define a inference server different than the production one.