### PR TITLE
Add cron task management to agents

### DIFF
--- a/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/agent.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/agent.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::{
-    schemas::{job_config::JobConfig, shinkai_name::ShinkaiName, tool_router_key::ToolRouterKey},
+    schemas::{job_config::JobConfig, shinkai_name::ShinkaiName, tool_router_key::ToolRouterKey, crontab::CronTask},
     shinkai_utils::job_scope::MinimalJobScope,
 };
 
@@ -25,6 +25,7 @@ pub struct Agent {
     pub config: Option<JobConfig>,
     #[serde(default)]
     pub scope: MinimalJobScope,
+    pub cron_tasks: Option<Vec<CronTask>>,
 }
 
 #[cfg(test)]

--- a/shinkai-libs/shinkai-sqlite/src/agent_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/agent_manager.rs
@@ -122,6 +122,7 @@ impl SqliteManager {
                         e.to_string(),
                     )))
                 })?,
+                cron_tasks: None,
             })
         })?;
 
@@ -178,6 +179,7 @@ impl SqliteManager {
                         e.to_string(),
                     )))
                 })?,
+                cron_tasks: None,
             })
         });
 

--- a/shinkai-libs/shinkai-sqlite/src/cron_task_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/cron_task_manager.rs
@@ -69,6 +69,51 @@ impl SqliteManager {
         }
     }
 
+    pub fn get_cron_task_by_llm_provider_id(&self, llm_provider_id: &str) -> Result<Option<CronTask>, SqliteManagerError> {
+        let conn = self.get_connection()?;
+        let mut stmt = conn.prepare(
+            "SELECT task_id, name, description, cron, created_at, last_modified, action, paused 
+             FROM cron_tasks",
+        )?;
+        let cron_task_iter = stmt.query_map([], |row| {
+            let action_json: String = row.get(6)?;
+            let action: CronTaskAction = serde_json::from_str(&action_json)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+
+            // Check if the action contains the matching llm_provider_id
+            let matches = match &action {
+                CronTaskAction::CreateJobWithConfigAndMessage { llm_provider, .. } => {
+                    llm_provider == llm_provider_id
+                }
+                _ => false,
+            };
+
+            if matches {
+                Ok(Some(CronTask {
+                    task_id: row.get(0)?,
+                    name: row.get(1)?,
+                    description: row.get(2)?,
+                    cron: row.get(3)?,
+                    created_at: row.get(4)?,
+                    last_modified: row.get(5)?,
+                    action,
+                    paused: row.get(7)?,
+                }))
+            } else {
+                Ok(None)
+            }
+        })?;
+
+        // Find the first matching task
+        for task_result in cron_task_iter {
+            if let Ok(Some(task)) = task_result {
+                return Ok(Some(task));
+            }
+        }
+
+        Ok(None)
+    }
+
     pub fn update_cron_task(
         &self,
         task_id: i64,


### PR DESCRIPTION
- Introduced `cron_tasks` field in the `Agent` struct to store associated cron tasks.
- Updated database retrieval methods to fetch and assign cron tasks for individual agents.
- Implemented a new method in `SqliteManager` to retrieve cron tasks by LLM provider ID.