### PR TITLE
Eduardo/get tool metadata endpoint

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1795,6 +1795,16 @@ impl Node {
                     let _ = Node::v2_api_list_all_shinkai_tools_versions(db_clone, bearer, res).await;
                 });
             }
+            NodeCommand::V2ApiGetShinkaiToolMetadata {
+                bearer,
+                tool_router_key,
+                res,
+            } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_get_shinkai_tool_metadata(db_clone, bearer, tool_router_key, res).await;
+                });
+            }
             NodeCommand::V2ApiSetShinkaiTool {
                 bearer,
                 tool_key,

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -1320,4 +1320,9 @@ pub enum NodeCommand {
         last: usize,
         res: Sender<Result<Vec<String>, APIError>>,
     },
+    V2ApiGetShinkaiToolMetadata {
+        bearer: String,
+        tool_router_key: String,
+        res: Sender<Result<Value, APIError>>,
+    }
 }

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/deno_tools.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/deno_tools.rs
@@ -15,6 +15,7 @@ use shinkai_tools_runner::tools::execution_context::ExecutionContext;
 use shinkai_tools_runner::tools::execution_error::ExecutionError;
 use shinkai_tools_runner::tools::run_result::RunResult;
 use shinkai_tools_runner::tools::shinkai_node_location::ShinkaiNodeLocation;
+use super::tool_playground::ToolPlaygroundMetadata;
 use std::collections::HashMap;
 use std::env;
 use std::fs::create_dir_all;
@@ -665,6 +666,27 @@ impl DenoTool {
             }
         }
         true
+    }
+
+    pub fn get_metadata(&self) -> ToolPlaygroundMetadata {
+        ToolPlaygroundMetadata {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            keywords: self.keywords.clone(),
+            homepage: self.homepage.clone(),
+            author: self.author.clone(),
+            version: self.version.clone(),
+            configurations: self.config.clone(),
+            parameters: self.input_args.clone(),
+            result: self.result.clone(),
+            sql_tables: self.sql_tables.clone().unwrap_or_default(),
+            sql_queries: self.sql_queries.clone().unwrap_or_default(),
+            tools: Some(self.tools.clone()),
+            oauth: self.oauth.clone(),
+            runner: self.runner.clone(),
+            operating_system: self.operating_system.clone(),
+            tool_set: self.tool_set.clone(),
+        }
     }
 }
 

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/python_tools.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/python_tools.rs
@@ -15,6 +15,7 @@ use shinkai_tools_runner::tools::python_runner::PythonRunner;
 use shinkai_tools_runner::tools::python_runner_options::PythonRunnerOptions;
 use shinkai_tools_runner::tools::run_result::RunResult;
 use shinkai_tools_runner::tools::shinkai_node_location::ShinkaiNodeLocation;
+use super::tool_playground::ToolPlaygroundMetadata;
 use std::collections::HashMap;
 use std::env;
 use std::fs::create_dir_all;
@@ -388,6 +389,27 @@ impl PythonTool {
                     }),
                 })
             }
+        }
+    }
+
+    pub fn get_metadata(&self) -> ToolPlaygroundMetadata {
+        ToolPlaygroundMetadata {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            keywords: self.keywords.clone(),
+            homepage: self.homepage.clone(),
+            author: self.author.clone(),
+            version: self.version.clone(),
+            configurations: self.config.clone(),
+            parameters: self.input_args.clone(),
+            result: self.result.clone(),
+            sql_tables: self.sql_tables.clone().unwrap_or_default(),
+            sql_queries: self.sql_queries.clone().unwrap_or_default(),
+            tools: Some(self.tools.clone()),
+            oauth: self.oauth.clone(),
+            runner: self.runner.clone(),
+            operating_system: self.operating_system.clone(),
+            tool_set: self.tool_set.clone(),
         }
     }
 }

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/shinkai_tool.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/shinkai_tool.rs
@@ -12,7 +12,7 @@ use shinkai_message_primitives::schemas::{
 
 use super::agent_tool_wrapper::AgentToolWrapper;
 use super::tool_config::OAuth;
-use super::tool_playground::{SqlQuery, SqlTable};
+use super::tool_playground::{SqlQuery, SqlTable, ToolPlaygroundMetadata};
 use super::tool_types::{OperatingSystem, RunnerType};
 use super::{
     deno_tools::DenoTool, network_tool::NetworkTool, parameters::Parameters, python_tools::PythonTool,
@@ -560,6 +560,14 @@ impl ShinkaiTool {
             ShinkaiTool::Deno(d, _) => d.keywords.clone(),
             ShinkaiTool::Python(p, _) => p.keywords.clone(),
             ShinkaiTool::Agent(_a, _) => vec![],
+        }
+    }
+
+    pub fn get_metadata(&self) -> Option<ToolPlaygroundMetadata> {
+        match self {
+            ShinkaiTool::Deno(d, _) => Some(d.get_metadata()),
+            ShinkaiTool::Python(p, _) => Some(p.get_metadata()),
+            _ => None,
         }
     }
 }

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/shinkai_tool.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/shinkai_tool.rs
@@ -567,6 +567,7 @@ impl ShinkaiTool {
         match self {
             ShinkaiTool::Deno(d, _) => Some(d.get_metadata()),
             ShinkaiTool::Python(p, _) => Some(p.get_metadata()),
+            ShinkaiTool::Rust(r, _) => Some(r.get_metadata()),
             _ => None,
         }
     }


### PR DESCRIPTION
Implemented for Rust, Deno and Python tools. Network and Agent tools return null but app defaults to using the tool as it has been until now.