### PR TITLE
Reduce Tokio and Reqwest features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ shinkai_non_rust_code = { path = "./shinkai-libs/shinkai-non-rust-code" }
 
 futures = "0.3.30"
 keyphrases = "0.3.3"
-tokio = { version = "1.36", features = ["full"] }
+tokio = { version = "1.36", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "sync", "time"] }
 tokio-util = "0.7.13"
 bincode = "1.3.3"
 log = "0.4.20"

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -19,7 +19,7 @@ console = ["console-subscriber"]
 doctest = false
 
 [dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 tokio-util = { workspace = true }
 log = { workspace = true }
 chrono = { workspace = true }
@@ -39,12 +39,7 @@ clap = "3.0.0-beta.5"
 regex = { workspace = true }
 csv = "1.1.6"
 uuid = { workspace = true, features = ["v4"] }
-reqwest = { workspace = true, features = [
-    "json",
-    "tokio-native-tls",
-    "blocking",
-    "stream",
-] }
+reqwest = { workspace = true, features = ["json", "tokio-native-tls", "multipart", "stream"] }
 keyphrases = { workspace = true }
 shinkai_message_primitives = { workspace = true }
 shinkai_crypto_identities = { workspace = true }

--- a/shinkai-libs/shinkai-crypto-identities/Cargo.toml
+++ b/shinkai-libs/shinkai-crypto-identities/Cargo.toml
@@ -7,7 +7,7 @@ authors = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 serde_json = { workspace = true }
 shinkai_message_primitives = { path = "../shinkai-message-primitives" }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }

--- a/shinkai-libs/shinkai-embedding/Cargo.toml
+++ b/shinkai-libs/shinkai-embedding/Cargo.toml
@@ -11,13 +11,7 @@ rand = { workspace = true }
 blake3 = { workspace = true }
 chrono = { workspace = true }
 thiserror = "2.0.3"
-reqwest = { workspace = true, features = [
-    "json",
-    "tokio-native-tls",
-    "blocking",
-    "multipart",
-    "default-tls",
-] }
+reqwest = { workspace = true, features = ["json", "tokio-native-tls", "blocking"] }
 lazy_static = "1.5.0"
 async-trait = { workspace = true }
 keyphrases = { workspace = true }

--- a/shinkai-libs/shinkai-fs/Cargo.toml
+++ b/shinkai-libs/shinkai-fs/Cargo.toml
@@ -12,7 +12,7 @@ bincode = { workspace = true }
 serde_json = { workspace = true }
 rand = { workspace = true }
 blake3 = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 chrono = { workspace = true }
 comrak = { version = "0.22.0", default-features = true }
 thiserror = "2.0.3"

--- a/shinkai-libs/shinkai-http-api/Cargo.toml
+++ b/shinkai-libs/shinkai-http-api/Cargo.toml
@@ -19,15 +19,10 @@ x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 ed25519-dalek = "2.1.0"
 shinkai_message_primitives = { workspace = true }
 shinkai_tools_primitives = { workspace = true }
-reqwest = { workspace = true, features = [
-    "json",
-    "tokio-native-tls",
-    "blocking",
-    "stream",
-] }
+reqwest = { workspace = true }
 tokio-stream = "0.1.10"
 rand = "0.9.0"
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 tokio-rustls = "0.23"
 rustls = "0.20"
 hyper = { version = "0.14.30", features = ["server"] }

--- a/shinkai-libs/shinkai-job-queue-manager/Cargo.toml
+++ b/shinkai-libs/shinkai-job-queue-manager/Cargo.toml
@@ -8,7 +8,7 @@ authors = { workspace = true }
 shinkai_message_primitives = { workspace = true }
 shinkai_sqlite = { workspace = true }
 shinkai_embedding = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
 

--- a/shinkai-libs/shinkai-message-primitives/Cargo.toml
+++ b/shinkai-libs/shinkai-message-primitives/Cargo.toml
@@ -22,7 +22,7 @@ rust_decimal = "1.17.0"
 base64 = { workspace = true }
 utoipa = "4.2.3"
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 async-trait = "0.1.74"
 
 tracing = { version = "0.1.40", optional = true }

--- a/shinkai-libs/shinkai-sheet/Cargo.toml
+++ b/shinkai-libs/shinkai-sheet/Cargo.toml
@@ -6,7 +6,7 @@ authors = { workspace = true }
 
 [dependencies]
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4"] }
 regex = { workspace = true }

--- a/shinkai-libs/shinkai-sqlite/Cargo.toml
+++ b/shinkai-libs/shinkai-sqlite/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.6"
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.25"
 keyphrases = { workspace = true }

--- a/shinkai-libs/shinkai-tcp-relayer/Cargo.toml
+++ b/shinkai-libs/shinkai-tcp-relayer/Cargo.toml
@@ -7,7 +7,7 @@ authors = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 serde_json = { workspace = true }
 clap = { version = "3", features = ["derive", "env"] }
 shinkai_message_primitives = { path = "../shinkai-message-primitives" }

--- a/shinkai-libs/shinkai-tools-primitives/Cargo.toml
+++ b/shinkai-libs/shinkai-tools-primitives/Cargo.toml
@@ -6,16 +6,11 @@ authors = { workspace = true }
 
 [dependencies]
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 regex = { workspace = true }
 shinkai_message_primitives = { workspace = true }
 # shinkai_vector_resources = { workspace = true }
-reqwest = { workspace = true, features = [
-    "json",
-    "tokio-native-tls",
-    "blocking",
-    "stream",
-] }
+reqwest = { workspace = true, features = ["json", "tokio-native-tls"] }
 anyhow = { workspace = true }
 shinkai_tools_runner = { workspace = true, features = ["built-in-tools"] }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary
- slim down feature sets in workspace `Cargo.toml`
- limit Tokio features across crates
- trim Reqwest features where unused

## Testing
- `cargo check -p shinkai_message_primitives`
- `CARGO_PUBLISH=1 cargo check -p shinkai_http_api` *(fails: curl download error)*