### PR TITLE
Fix lint warnings

### DIFF
--- a/shinkai-libs/shinkai-embedding/src/embedding_generator.rs
+++ b/shinkai-libs/shinkai-embedding/src/embedding_generator.rs
@@ -467,6 +467,7 @@ impl RemoteEmbeddingGenerator {
     }
 
     /// Generates embeddings using a Hugging Face Text Embeddings Inference server
+    #[allow(dead_code)]
     fn generate_embedding_tei_blocking(
         &self,
         input_strings: Vec<String>,
@@ -593,6 +594,7 @@ impl RemoteEmbeddingGenerator {
     }
 
     /// Generate an Embedding for an input string by using the external OpenAI-matching API.
+    #[allow(dead_code)]
     fn generate_embedding_open_ai_blocking(&self, input_string: &str) -> Result<Vec<f32>, ShinkaiEmbeddingError> {
         // Prepare the request body
         let request_body = EmbeddingRequestBody {

--- a/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/agent.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/agent.rs
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_agent_with_tools_config_override() {
-        use serde_json::{json, Map};
+        use serde_json::json;
         use std::collections::HashMap;
 
         // Create a test agent with tools_config_override

--- a/shinkai-libs/shinkai-message-primitives/src/shinkai_utils/shinkai_path.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/shinkai_utils/shinkai_path.rs
@@ -1,6 +1,5 @@
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json;
 use std::env;
 use std::fmt;
 use std::hash::Hash;

--- a/shinkai-libs/shinkai-message-primitives/src/shinkai_utils/utils.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/shinkai_utils/utils.rs
@@ -34,7 +34,7 @@ pub fn random_string() -> String {
 pub fn count_tokens_from_message_llama3(message: &str) -> usize {
     let mut token_count = 0;
     let mut alphabetic_count = 0; // Total count of alphabetic characters
-    let mut space_count = 0; // Total count of spaces
+    let mut _space_count = 0; // Total count of spaces
                              // ^ need to fix this
 
     // First pass: count alphabetic characters and spaces
@@ -42,7 +42,7 @@ pub fn count_tokens_from_message_llama3(message: &str) -> usize {
         if c.is_ascii_alphabetic() {
             alphabetic_count += 1;
         } else if c.is_whitespace() {
-            space_count += 1;
+            _space_count += 1;
         }
     }
 
@@ -58,7 +58,7 @@ pub fn count_tokens_from_message_llama3(message: &str) -> usize {
             token_count += alphabetic_token_weight; // Counting as 1/3, so add 1 to the scaled count
         } else if c.is_whitespace() {
             if spaces_to_ignore > 0 {
-                space_count -= 10; // Reduce the count of spaces to ignore by the scaling factor
+                _space_count -= 10; // Reduce the count of spaces to ignore by the scaling factor
             } else {
                 token_count += 30; // Count the space as a full token if not enough alphabetic characters
             }

--- a/shinkai-libs/shinkai-message-primitives/tests/shinkai_message_tests.rs
+++ b/shinkai-libs/shinkai-message-primitives/tests/shinkai_message_tests.rs
@@ -58,7 +58,7 @@ mod tests {
     fn test_serde_encode_decode_message() {
         // Initialize the message
         let (my_encryption_secret_key, my_encryption_public_key) = unsafe_deterministic_encryption_keypair(0);
-        let (my_signature_secret_key, my_signature_public_key) = unsafe_deterministic_signature_keypair(0);
+        let (my_signature_secret_key, _my_signature_public_key) = unsafe_deterministic_signature_keypair(0);
         let receiver_public_key = my_encryption_public_key.clone();
 
         let message = ShinkaiMessageBuilder::new(

--- a/shinkai-libs/shinkai-non-rust-code/src/lib.rs
+++ b/shinkai-libs/shinkai-non-rust-code/src/lib.rs
@@ -52,6 +52,7 @@ pub enum NonRustRuntime {
     Python,
 }
 
+#[allow(dead_code)]
 fn get_python_binary_path() -> PathBuf {
     PathBuf::from(env::var("SHINKAI_TOOLS_RUNNER_PYTHON_BINARY_PATH").unwrap_or_else(|_| "python3".to_string()))
 }

--- a/shinkai-libs/shinkai-sqlite/src/lib.rs
+++ b/shinkai-libs/shinkai-sqlite/src/lib.rs
@@ -153,7 +153,7 @@ impl SqliteManager {
                     agent.full_identity_name.node_name.clone(),
                     agent.agent_id
                 ))
-                .map_err(|e| SqliteManagerError::InvalidData)?;
+                .map_err(|_| SqliteManagerError::InvalidData)?;
                 manager.update_agent(agent)?;
             }
         }
@@ -580,7 +580,7 @@ impl SqliteManager {
     }
 
     fn initialize_tools_table(conn: &rusqlite::Connection) -> Result<()> {
-        let result = conn.execute(
+        conn.execute(
             "CREATE TABLE IF NOT EXISTS shinkai_tools (
                 name TEXT NOT NULL,
                 description TEXT,

--- a/shinkai-libs/shinkai-sqlite/src/preferences.rs
+++ b/shinkai-libs/shinkai-sqlite/src/preferences.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use crate::errors::SqliteManagerError;
 use crate::SqliteManager;
-use crate::preferences::serde_json::Value;
 use rusqlite::{OptionalExtension, Result, ToSql};
 use serde;
 use serde_json;

--- a/shinkai-libs/shinkai-sqlite/src/regex_pattern_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/regex_pattern_manager.rs
@@ -1,5 +1,4 @@
 use rusqlite::{Result, Row, ToSql, OptionalExtension};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{errors::SqliteManagerError, SqliteManager};
 

--- a/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
@@ -1,5 +1,4 @@
 use crate::{SqliteManager, SqliteManagerError};
-use bincode::Error;
 use bytemuck::cast_slice;
 use keyphrases::KeyPhraseExtractor;
 use rusqlite::{params, Result};

--- a/shinkai-libs/shinkai-sqlite/src/tool_playground.rs
+++ b/shinkai-libs/shinkai-sqlite/src/tool_playground.rs
@@ -2,8 +2,10 @@ use crate::{SqliteManager, SqliteManagerError};
 use rusqlite::{params, Result};
 use serde_json;
 use shinkai_message_primitives::schemas::{
-    indexable_version::IndexableVersion, shinkai_tools::CodeLanguage, tool_router_key::ToolRouterKey
+    indexable_version::IndexableVersion, shinkai_tools::CodeLanguage,
 };
+#[cfg(test)]
+use shinkai_message_primitives::schemas::tool_router_key::ToolRouterKey;
 use shinkai_tools_primitives::tools::{
     tool_playground::{ToolPlayground, ToolPlaygroundMetadata}, tool_types::{OperatingSystem, RunnerType}
 };

--- a/shinkai-libs/shinkai-tcp-relayer/tests/server_tests.rs
+++ b/shinkai-libs/shinkai-tcp-relayer/tests/server_tests.rs
@@ -562,7 +562,6 @@ pub fn generate_message_with_payload<T: ToString>(
         .unwrap()
 }
 
-#[allow(dead_code)]
 async fn create_shinkai_message_for_shared_files(
     sender: &str,
     recipient: &str,


### PR DESCRIPTION
## Summary
- tidy unused imports and unused variables across libs
- silence unused functions in embedding generator
- adjust tests-only imports

## Testing
- `cargo check -p shinkai_message_primitives --tests --offline` *(with warnings)*