### PR TITLE
Fix some warnings and update base64 usage

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/generic_chain/generic_inference_chain.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/generic_chain/generic_inference_chain.rs
@@ -38,6 +38,7 @@ use std::result::Result::Ok;
 use std::time::Instant;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
+use base64::Engine;
 
 #[derive(Clone)]
 pub struct GenericInferenceChain {
@@ -120,7 +121,7 @@ impl GenericInferenceChain {
                     // Retrieve the file content
                     match ShinkaiFileManager::get_file_content(file_path.clone()) {
                         Ok(content) => {
-                            let base64_content = base64::encode(&content);
+                            let base64_content = base64::engine::general_purpose::STANDARD.encode(&content);
                             image_files.insert(file_path.relative_path().to_string(), base64_content);
                         }
                         Err(_) => continue,
@@ -140,7 +141,7 @@ impl GenericInferenceChain {
                 {
                     match ShinkaiFileManager::get_file_content(file_path.clone()) {
                         Ok(content) => {
-                            let base64_content = base64::encode(&content);
+                            let base64_content = base64::engine::general_purpose::STANDARD.encode(&content);
                             image_files.insert(file_path.relative_path().to_string(), base64_content);
                         }
                         Err(_) => continue,
@@ -170,7 +171,7 @@ impl GenericInferenceChain {
                             let shinkai_path = ShinkaiPath::from_string(path.to_string_lossy().to_string());
                             match ShinkaiFileManager::get_file_content(shinkai_path.clone()) {
                                 Ok(content) => {
-                                    let base64_content = base64::encode(&content);
+                                    let base64_content = base64::engine::general_purpose::STANDARD.encode(&content);
                                     image_files.insert(shinkai_path.relative_path().to_string(), base64_content);
                                 }
                                 Err(_) => continue,

--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/job_execution_core.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/job_execution_core.rs
@@ -22,6 +22,7 @@ use shinkai_message_primitives::{
     schemas::shinkai_name::ShinkaiName, shinkai_message::shinkai_message_schemas::JobMessage, shinkai_utils::{shinkai_message_builder::ShinkaiMessageBuilder, signatures::clone_signature_secret_key}
 };
 use shinkai_sqlite::SqliteManager;
+use base64::Engine;
 use std::result::Result::Ok;
 use std::sync::Weak;
 use std::time::Instant;
@@ -328,7 +329,7 @@ impl JobManager {
                     // Retrieve the file content
                     match ShinkaiFileManager::get_file_content(file_path.clone()) {
                         Ok(content) => {
-                            let base64_content = base64::encode(&content);
+                            let base64_content = base64::engine::general_purpose::STANDARD.encode(&content);
                             image_files.insert(file_path.relative_path().to_string(), base64_content);
                         }
                         Err(_) => continue,
@@ -351,7 +352,7 @@ impl JobManager {
                         // Retrieve the file content
                         match ShinkaiFileManager::get_file_content(file_path.clone()) {
                             Ok(content) => {
-                                let base64_content = base64::encode(&content);
+                                let base64_content = base64::engine::general_purpose::STANDARD.encode(&content);
                                 image_files.insert(filename.clone(), base64_content);
                             }
                             Err(_) => continue,

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/shared/shared_model_logic.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/shared/shared_model_logic.rs
@@ -1,4 +1,5 @@
-use base64::decode;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use shinkai_message_primitives::{schemas::{
     llm_providers::serialized_llm_provider::LLMProviderInterface, prompts::Prompt,
 }, shinkai_utils::utils::count_tokens_from_message_llama3};
@@ -28,7 +29,7 @@ pub fn llama_prepare_messages(
 }
 
 pub fn get_image_type(base64_str: &str) -> Option<&'static str> {
-    let decoded = decode(base64_str).ok()?;
+    let decoded = BASE64.decode(base64_str).ok()?;
     if decoded.starts_with(&[0xFF, 0xD8, 0xFF]) {
         Some("jpeg")
     } else if decoded.starts_with(&[0x89, b'P', b'N', b'G', b'\r', b'\n', b'\x1A', b'\n']) {

--- a/shinkai-bin/shinkai-node/src/managers/galxe_quests.rs
+++ b/shinkai-bin/shinkai-node/src/managers/galxe_quests.rs
@@ -10,6 +10,7 @@ use shinkai_message_primitives::schemas::shinkai_name::ShinkaiName;
 use shinkai_message_primitives::shinkai_utils::signatures::unsafe_deterministic_signature_keypair;
 use shinkai_sqlite::SqliteManager;
 use std::sync::Arc;
+use base64::Engine;
 use x25519_dalek::PublicKey as EncryptionPublicKey;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -701,7 +702,7 @@ pub fn generate_proof(node_signature: String, payload: String) -> Result<(String
         "{}:::{}:::{}",
         public_key_hex,
         last_8_chars,
-        base64::encode(payload.as_bytes())
+        base64::engine::general_purpose::STANDARD.encode(payload.as_bytes())
     );
 
     // Create the final signature by:

--- a/shinkai-bin/shinkai-node/src/network/node.rs
+++ b/shinkai-bin/shinkai-node/src/network/node.rs
@@ -18,6 +18,7 @@ use async_channel::Receiver;
 use chashmap::CHashMap;
 use chrono::Utc;
 use core::panic;
+use base64::Engine;
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 use futures::{future::FutureExt, pin_mut, prelude::*, select};
 use rand::rngs::OsRng;
@@ -1586,7 +1587,7 @@ impl Node {
     fn generate_api_v2_key() -> String {
         let mut key = [0u8; 32]; // 256-bit key
         OsRng.fill_bytes(&mut key);
-        base64::encode(&key)
+        base64::engine::general_purpose::STANDARD.encode(&key)
     }
 
     pub fn generic_api_error(e: &str) -> APIError {

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_oauth.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_oauth.rs
@@ -8,11 +8,11 @@ use serde_json::Value;
 use shinkai_sqlite::SqliteManager;
 
 use std::sync::Arc;
+use base64::Engine;
 
 use reqwest::Client;
 use shinkai_http_api::node_api_router::APIError;
 
-use base64;
 
 impl Node {
     pub async fn v2_api_get_oauth_token(
@@ -176,7 +176,7 @@ impl Node {
                     if let (Some(client_id), Some(client_secret)) =
                         (oauth_data.client_id.clone(), oauth_data.client_secret.clone())
                     {
-                        let auth = base64::encode(format!("{}:{}", client_id, client_secret));
+                        let auth = base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", client_id, client_secret));
                         request = request.header("Authorization", format!("Basic {}", auth));
                     }
                 }
@@ -195,7 +195,7 @@ impl Node {
                     if let (Some(client_id), Some(client_secret)) =
                         (oauth_data.client_id.clone(), oauth_data.client_secret.clone())
                     {
-                        let auth = base64::encode(format!("{}:{}", client_id, client_secret));
+                        let auth = base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", client_id, client_secret));
                         request = request.header("Authorization", format!("Basic {}", auth));
                     }
                 }

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_tools.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_tools.rs
@@ -65,6 +65,7 @@ use tokio::fs;
 use tokio::{process::Command, sync::Mutex};
 use x25519_dalek::PublicKey as EncryptionPublicKey;
 use x25519_dalek::StaticSecret as EncryptionStaticKey;
+use base64::Engine;
 
 // Helper function to serialize Vec<ToolConfig> into the specific object format
 fn serialize_tool_config_to_schema_and_form_data(configs: &Vec<ToolConfig>) -> Value {
@@ -726,7 +727,7 @@ impl Node {
                         // Create the assets
                         for asset in assets {
                             let asset_path = file_path.join(asset.file_name);
-                            let asset_content = base64::decode(asset.data).unwrap();
+                            let asset_content = base64::engine::general_purpose::STANDARD.decode(asset.data).unwrap();
                             let status = fs::write(asset_path, asset_content).await;
                             if status.is_err() {
                                 let api_error = APIError {

--- a/shinkai-bin/shinkai-node/src/network/ws_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/ws_manager.rs
@@ -18,7 +18,6 @@ use shinkai_message_primitives::schemas::ws_types::WebSocketManagerError;
 use shinkai_message_primitives::shinkai_message::shinkai_message::ShinkaiMessage;
 use shinkai_message_primitives::shinkai_message::shinkai_message_schemas::WSMessage;
 use shinkai_message_primitives::shinkai_message::shinkai_message_schemas::WSTopic;
-use shinkai_message_primitives::shinkai_utils::encryption::clone_static_secret_key;
 use shinkai_message_primitives::shinkai_utils::shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption};
 use shinkai_sqlite::SqliteManager;
 use std::collections::VecDeque;

--- a/shinkai-bin/shinkai-node/src/runner.rs
+++ b/shinkai-bin/shinkai-node/src/runner.rs
@@ -8,7 +8,6 @@ use crate::utils::qr_code_setup::generate_qr_codes;
 use async_channel::{bounded, Receiver, Sender};
 use ed25519_dalek::VerifyingKey;
 use shinkai_embedding::embedding_generator::RemoteEmbeddingGenerator;
-use shinkai_fs::simple_parser::file_parser_helper::ShinkaiFileParser;
 use shinkai_http_api::node_api_router;
 use shinkai_http_api::node_commands::NodeCommand;
 use shinkai_message_primitives::shinkai_utils::encryption::{

--- a/shinkai-bin/shinkai-node/src/tools/tool_execution/execute_agent_dynamic.rs
+++ b/shinkai-bin/shinkai-node/src/tools/tool_execution/execute_agent_dynamic.rs
@@ -1,18 +1,16 @@
-use std::{collections::HashMap, path::PathBuf};
 
-use super::execution_header_generator::{check_tool, generate_execution_environment};
+
+use super::execution_header_generator::generate_execution_environment;
 use crate::llm_provider::job_manager::JobManager;
 use crate::tools::agent_execution::v2_create_and_send_job_message_for_agent;
 use crate::tools::tool_generation::v2_send_basic_job_message_for_existing_job;
-use crate::utils::environment::fetch_node_environment;
-use crate::{managers::IdentityManager, network::Node};
+use crate::managers::IdentityManager;
+use crate::network::Node;
 use ed25519_dalek::SigningKey;
 use serde_json::{Map, Value};
 use shinkai_message_primitives::schemas::{inbox_name::InboxName, shinkai_name::ShinkaiName};
 use shinkai_sqlite::SqliteManager;
-use shinkai_tools_primitives::tools::{
-    error::ToolError, parameters::Parameters, python_tools::PythonTool, tool_config::{OAuth, ToolConfig}, tool_output_arg::ToolOutputArg, tool_types::{OperatingSystem, RunnerType, ToolResult}
-};
+use shinkai_tools_primitives::tools::error::ToolError;
 use std::sync::Arc;
 use tokio::{
     sync::Mutex, time::{sleep, Duration}

--- a/shinkai-bin/shinkai-node/src/tools/tool_implementation/native_tools/typescript_unsafe_processor.rs
+++ b/shinkai-bin/shinkai-node/src/tools/tool_implementation/native_tools/typescript_unsafe_processor.rs
@@ -16,7 +16,6 @@ use x25519_dalek::StaticSecret as EncryptionStaticKey;
 
 use crate::llm_provider::job_manager::JobManager;
 use crate::managers::IdentityManager;
-use crate::network::Node;
 use crate::tools::tool_execution::execution_header_generator::generate_execution_environment;
 use crate::tools::tool_implementation::tool_traits::ToolExecutor;
 

--- a/shinkai-bin/shinkai-node/src/wallet/coinbase_mpc_wallet.rs
+++ b/shinkai-bin/shinkai-node/src/wallet/coinbase_mpc_wallet.rs
@@ -13,7 +13,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
-use tokio::sync::RwLock;
 
 use super::wallet_manager::WalletEnum;
 use super::wallet_traits::{CommonActions, IsWallet, PaymentWallet, ReceivingWallet, SendActions, TransactionHash};

--- a/shinkai-bin/shinkai-node/src/wallet/wallet_manager.rs
+++ b/shinkai-bin/shinkai-node/src/wallet/wallet_manager.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use shinkai_message_primitives::schemas::{
-    coinbase_mpc_config::CoinbaseMPCWalletConfig, invoices::{Invoice, Payment, PaymentStatusEnum}, shinkai_name::ShinkaiName, shinkai_tool_offering::ToolPrice, wallet_complementary::WalletSource, wallet_mixed::{Asset, Balance, Network, PublicAddress}
+    coinbase_mpc_config::CoinbaseMPCWalletConfig, invoices::{Invoice, Payment, PaymentStatusEnum}, shinkai_name::ShinkaiName, shinkai_tool_offering::ToolPrice, wallet_mixed::{Asset, Balance, Network, PublicAddress}
 };
 use shinkai_sqlite::SqliteManager;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary
- clean unused imports in multiple modules
- update deprecated `base64::encode`/`decode` calls to use the new Engine API
- add missing `base64::Engine` trait imports

## Testing
- `cargo check -p shinkai_node` *(fails: failed to download deno binary)*