### PR TITLE
Fix unused variable warnings

### DIFF
--- a/shinkai-bin/shinkai-node/src/managers/galxe_quests.rs
+++ b/shinkai-bin/shinkai-node/src/managers/galxe_quests.rs
@@ -463,7 +463,7 @@ pub async fn compute_create_tool_quest(db: Arc<SqliteManager>) -> Result<bool, S
     Ok(created_tools > 0)
 }
 
-pub async fn compute_submit_approval_quest(db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<bool, String> {
+pub async fn compute_submit_approval_quest(_db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<bool, String> {
     let url = format!("https://store-api.shinkai.com/user/{}/apps", node_name.to_string());
 
     let client = reqwest::Client::new();
@@ -487,7 +487,7 @@ pub async fn compute_submit_approval_quest(db: Arc<SqliteManager>, node_name: Sh
     Ok(!apps.is_empty())
 }
 
-pub async fn compute_top_ranking_quest(db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<bool, String> {
+pub async fn compute_top_ranking_quest(_db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<bool, String> {
     let url = format!("https://store-api.shinkai.com/user/{}/apps", node_name.to_string());
 
     let client = reqwest::Client::new();
@@ -515,7 +515,7 @@ pub async fn compute_top_ranking_quest(db: Arc<SqliteManager>, node_name: Shinka
     Ok(has_featured)
 }
 
-pub async fn compute_write_app_reviews_quest(db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<bool, String> {
+pub async fn compute_write_app_reviews_quest(_db: Arc<SqliteManager>, node_name: ShinkaiName) -> Result<bool, String> {
     let url = format!("https://store-api.shinkai.com/user/{}/reviews", node_name.to_string());
 
     let client = reqwest::Client::new();
@@ -721,7 +721,7 @@ pub fn generate_proof(node_signature: String, payload: String) -> Result<(String
 }
 
 pub async fn compute_submit_approval_quest_with_count(
-    db: Arc<SqliteManager>,
+    _db: Arc<SqliteManager>,
     node_name: ShinkaiName,
     required_count: usize,
 ) -> Result<bool, String> {
@@ -749,7 +749,7 @@ pub async fn compute_submit_approval_quest_with_count(
 }
 
 pub async fn compute_write_app_reviews_quest_with_count(
-    db: Arc<SqliteManager>,
+    _db: Arc<SqliteManager>,
     node_name: ShinkaiName,
     required_count: usize,
 ) -> Result<bool, String> {

--- a/shinkai-bin/shinkai-node/src/managers/tool_router.rs
+++ b/shinkai-bin/shinkai-node/src/managers/tool_router.rs
@@ -807,7 +807,7 @@ impl ToolRouter {
         let agent = context.agent().clone();
         match agent {
             ProviderOrAgent::Agent(agent) => {
-                if let Some(agent_id) = &agent_id {
+                if agent_id.is_some() {
                     function_config_vec = override_tool_config(
                         shinkai_tool.tool_router_key().to_string_without_version().clone(),
                         agent,


### PR DESCRIPTION
## Summary
- silence warnings in galxe_quests by marking unused `db` arguments
- avoid creating an unused shadow variable in tool_router

## Testing
- `cargo check -p shinkai_node` *(fails: failed to download deno binary)*