### PR TITLE
Fix unreachable patterns and if-let warnings

### DIFF
--- a/shinkai-libs/shinkai-sqlite/src/embedding_function.rs
+++ b/shinkai-libs/shinkai-sqlite/src/embedding_function.rs
@@ -24,13 +24,10 @@ impl EmbeddingFunction {
     }
 
     pub async fn request_embeddings(&self, prompt: &str) -> Result<Vec<f32>, rusqlite::Error> {
-        let model_str = match &self.model_type {
-            EmbeddingModelType::OllamaTextEmbeddingsInference(model) => model.to_string(),
-            _ => {
-                println!("Unsupported embedding model type: {:?}", self.model_type);
-                return Err(rusqlite::Error::InvalidQuery);
-            }
-        };
+        // Currently `EmbeddingModelType` only supports `OllamaTextEmbeddingsInference`.
+        // Using a `match` with a catch-all arm triggers an `unreachable_pattern`
+        // warning, so directly convert the enum to a string instead.
+        let model_str = self.model_type.to_string();
 
         let max_tokens = self.model_type.max_input_token_count();
         let truncated_prompt = if prompt.len() > max_tokens {

--- a/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
@@ -160,10 +160,9 @@ impl SqliteManager {
                     .map(|new_entry| match new_entry {
                         ToolConfig::BasicConfig(new_basic) => {
                             let preserved_value = old_config.iter().find_map(|old_entry| {
-                                if let ToolConfig::BasicConfig(old_basic) = old_entry {
-                                    if old_basic.key_name == new_basic.key_name {
-                                        return old_basic.key_value.clone();
-                                    }
+                                let ToolConfig::BasicConfig(old_basic) = old_entry;
+                                if old_basic.key_name == new_basic.key_name {
+                                    return old_basic.key_value.clone();
                                 }
                                 None
                             });
@@ -191,10 +190,9 @@ impl SqliteManager {
                     .map(|new_entry| match new_entry {
                         ToolConfig::BasicConfig(new_basic) => {
                             let preserved_value = old_config.iter().find_map(|old_entry| {
-                                if let ToolConfig::BasicConfig(old_basic) = old_entry {
-                                    if old_basic.key_name == new_basic.key_name {
-                                        return old_basic.key_value.clone();
-                                    }
+                                let ToolConfig::BasicConfig(old_basic) = old_entry;
+                                if old_basic.key_name == new_basic.key_name {
+                                    return old_basic.key_value.clone();
                                 }
                                 None
                             });
@@ -222,10 +220,9 @@ impl SqliteManager {
                     .map(|new_entry| match new_entry {
                         ToolConfig::BasicConfig(new_basic) => {
                             let preserved_value = old_config.iter().find_map(|old_entry| {
-                                if let ToolConfig::BasicConfig(old_basic) = old_entry {
-                                    if old_basic.key_name == new_basic.key_name {
-                                        return old_basic.key_value.clone();
-                                    }
+                                let ToolConfig::BasicConfig(old_basic) = old_entry;
+                                if old_basic.key_name == new_basic.key_name {
+                                    return old_basic.key_value.clone();
                                 }
                                 None
                             });
@@ -1018,14 +1015,13 @@ impl SqliteManager {
                     for (key_to_set, value_to_set) in &values {
                         // Iterate through the tool's config entries
                         for config_entry in &mut deno_tool.config {
-                            if let ToolConfig::BasicConfig(basic_config) = config_entry {
-                                // 2.1 Check if the key_name matches
-                                if &basic_config.key_name == key_to_set {
-                                    // 2.2 Set the key_value
-                                    basic_config.key_value = Some(value_to_set.clone());
-                                    config_updated = true;
-                                    break; // Move to the next key-value pair once matched
-                                }
+                            let ToolConfig::BasicConfig(basic_config) = config_entry;
+                            // 2.1 Check if the key_name matches
+                            if &basic_config.key_name == key_to_set {
+                                // 2.2 Set the key_value
+                                basic_config.key_value = Some(value_to_set.clone());
+                                config_updated = true;
+                                break; // Move to the next key-value pair once matched
                             }
                         }
                     }
@@ -1035,14 +1031,13 @@ impl SqliteManager {
                     for (key_to_set, value_to_set) in &values {
                         // Iterate through the tool's config entries
                         for config_entry in &mut python_tool.config {
-                            if let ToolConfig::BasicConfig(basic_config) = config_entry {
-                                // 2.1 Check if the key_name matches
-                                if &basic_config.key_name == key_to_set {
-                                    // 2.2 Set the key_value
-                                    basic_config.key_value = Some(value_to_set.clone());
-                                    config_updated = true;
-                                    break; // Move to the next key-value pair once matched
-                                }
+                            let ToolConfig::BasicConfig(basic_config) = config_entry;
+                            // 2.1 Check if the key_name matches
+                            if &basic_config.key_name == key_to_set {
+                                // 2.2 Set the key_value
+                                basic_config.key_value = Some(value_to_set.clone());
+                                config_updated = true;
+                                break; // Move to the next key-value pair once matched
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- remove unreachable match arm when choosing embedding model
- replace irrefutable `if let` patterns with direct matches in config merging
- update config mutations to use direct pattern matching

## Testing
- `CARGO_PUBLISH=1 cargo check -p shinkai_sqlite`