### PR TITLE
Fix wallet manager test

### DIFF
--- a/shinkai-libs/shinkai-sqlite/src/wallet_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/wallet_manager.rs
@@ -74,8 +74,8 @@ mod tests {
         let result = manager.save_wallet_manager(&wallet_data);
         assert!(result.is_ok());
 
-        let wallet_data = manager.read_wallet_manager().unwrap();
-        assert_eq!(wallet_data, wallet_data);
+        let retrieved_wallet_data = manager.read_wallet_manager().unwrap();
+        assert_eq!(retrieved_wallet_data, wallet_data);
 
         // Update wallet data
         let wallet_data = serde_json::json!({
@@ -86,8 +86,8 @@ mod tests {
         let result = manager.save_wallet_manager(&wallet_data);
         assert!(result.is_ok());
 
-        let wallet_data = manager.read_wallet_manager().unwrap();
-        assert_eq!(wallet_data, wallet_data);
+        let retrieved_wallet_data = manager.read_wallet_manager().unwrap();
+        assert_eq!(retrieved_wallet_data, wallet_data);
 
         // Verify that shinkai_wallet table has only one row
         let conn = manager.get_connection().unwrap();


### PR DESCRIPTION
## Summary
- fix wallet manager test to properly compare saved and retrieved data

## Testing
- `cargo test -p shinkai_sqlite -- --test-threads=1`