### PR TITLE
Remove unused dependencies

### DIFF
--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -70,7 +70,6 @@ serde = { workspace = true, features = ["derive"] }
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.25"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
-async-std = { version = "1.5.0", features = ["unstable"] }
 env_logger = { workspace = true }
 zip = "2.2.1"
 open = "5.3.2"

--- a/shinkai-bin/shinkai-node/src/managers/tool_router.rs
+++ b/shinkai-bin/shinkai-node/src/managers/tool_router.rs
@@ -13,7 +13,7 @@ use crate::tools::tool_execution::{
     execute_agent_dynamic::execute_agent_tool, execution_coordinator::override_tool_config, execution_custom::try_to_execute_rust_tool, execution_header_generator::{check_tool, generate_execution_environment}
 };
 use crate::utils::environment::{fetch_node_environment, NodeEnvironment};
-use async_std::path::PathBuf;
+use std::path::PathBuf;
 use ed25519_dalek::SigningKey;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -190,7 +190,7 @@ impl ToolRouter {
             }
         };
 
-        if !directory_path.exists().await {
+        if !directory_path.exists() {
             eprintln!("Install directory not found: {}", directory_path.display());
             return Ok(());
         }

--- a/shinkai-bin/shinkai-node/src/network/node.rs
+++ b/shinkai-bin/shinkai-node/src/network/node.rs
@@ -548,7 +548,7 @@ impl Node {
         pin_mut!(listen_future);
 
         let retry_interval_secs = 2;
-        let mut retry_interval = async_std::stream::interval(Duration::from_secs(retry_interval_secs));
+        let mut retry_interval = tokio::time::interval(Duration::from_secs(retry_interval_secs));
 
         let ping_interval_secs = if self.ping_interval_secs == 0 {
             315576000 * 10 // 10 years in seconds
@@ -561,23 +561,23 @@ impl Node {
             &format!("Automatic Ping interval set to {} seconds", ping_interval_secs),
         );
 
-        let mut ping_interval = async_std::stream::interval(Duration::from_secs(ping_interval_secs));
+        let mut ping_interval = tokio::time::interval(Duration::from_secs(ping_interval_secs));
         let mut commands_clone = self.commands.clone();
         // TODO: here we can create a task to check the blockchain for new peers and update our list
         let check_peers_interval_secs = 5;
-        let _check_peers_interval = async_std::stream::interval(Duration::from_secs(check_peers_interval_secs));
+        let _check_peers_interval = tokio::time::interval(Duration::from_secs(check_peers_interval_secs));
 
         // Add 6-hour interval for periodic tasks
         let six_hours_in_secs = 6 * 60 * 60; // 6 hours in seconds
-        let mut six_hour_interval = async_std::stream::interval(Duration::from_secs(six_hours_in_secs));
+        let mut six_hour_interval = tokio::time::interval(Duration::from_secs(six_hours_in_secs));
 
         // TODO: implement a TCP connection here with a proxy if it's set
 
         loop {
-            let ping_future = ping_interval.next().fuse();
+            let ping_future = ping_interval.tick().fuse();
             let commands_future = commands_clone.next().fuse();
-            let retry_future = retry_interval.next().fuse();
-            let six_hour_future = six_hour_interval.next().fuse();
+            let retry_future = retry_interval.tick().fuse();
+            let six_hour_future = six_hour_interval.tick().fuse();
 
             // TODO: update this to read onchain data and update db
             // let check_peers_future = check_peers_interval.next().fuse();

--- a/shinkai-libs/shinkai-http-api/Cargo.toml
+++ b/shinkai-libs/shinkai-http-api/Cargo.toml
@@ -27,8 +27,6 @@ tokio-rustls = "0.23"
 rustls = "0.20"
 hyper = { version = "0.14.30", features = ["server"] }
 rustls-pemfile = "1.0.3"
-mcp_sdk_core = { package = "mcp-core", git = "https://github.com/modelcontextprotocol/rust-sdk.git", branch = "main" }
-mcp_sdk_server = { package = "mcp-server", git = "https://github.com/modelcontextprotocol/rust-sdk.git", branch = "main" }
 tokio-util = { version = "0.7.10", features = ["codec"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 tracing = "0.1.40"


### PR DESCRIPTION
## Summary
- drop `async-std` usage in shinkai_node
- swap async_std intervals for `tokio::time::interval`
- use `std::path::PathBuf` for directory checks
- remove unused MCP SDK dependencies

## Testing
- `cargo check -p shinkai_node --quiet`
