### PR TITLE
Fix duplicate workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,19 +3667,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
- "zerocopy 0.8.10",
 ]
 
 [[package]]
@@ -3690,16 +3679,6 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3724,15 +3703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -4599,7 +4569,7 @@ dependencies = [
  "mcp-core",
  "mcp-server",
  "once_cell",
- "rand 0.9.0",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "rmcp",
  "rustls 0.20.9",

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -27,7 +27,7 @@ futures = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
-async-trait = "0.1.74"
+async-trait = { workspace = true }
 warp = { version = "0.3.7", features = ["compression-gzip"] }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 ed25519-dalek = "2.1.0"

--- a/shinkai-libs/shinkai-http-api/Cargo.toml
+++ b/shinkai-libs/shinkai-http-api/Cargo.toml
@@ -9,7 +9,7 @@ utoipa = "4.2.3"
 utoipa-swagger-ui = "7.1.0"
 chrono = { workspace = true }
 bytes = "1.10.1"
-async-trait = "0.1.75"
+async-trait = { workspace = true }
 once_cell = "1.19.0"
 warp = { version = "0.3.7", features = ["compression-gzip", "tls"] }
 serde_json = { workspace = true }
@@ -21,7 +21,7 @@ shinkai_message_primitives = { workspace = true }
 shinkai_tools_primitives = { workspace = true }
 reqwest = { workspace = true }
 tokio-stream = "0.1.10"
-rand = "0.9.0"
+rand = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = "0.23"
 rustls = "0.20"
@@ -29,8 +29,8 @@ hyper = { version = "0.14.30", features = ["server"] }
 rustls-pemfile = "1.0.3"
 mcp_sdk_core = { package = "mcp-core", git = "https://github.com/modelcontextprotocol/rust-sdk.git", branch = "main" }
 mcp_sdk_server = { package = "mcp-server", git = "https://github.com/modelcontextprotocol/rust-sdk.git", branch = "main" }
-tokio-util = { version = "0.7.10", features = ["codec"] }
-uuid = { version = "1.7.0", features = ["v4"] }
+tokio-util = { workspace = true, features = ["codec"] }
+uuid = { workspace = true, features = ["v4"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 anyhow = { workspace = true }

--- a/shinkai-libs/shinkai-message-primitives/Cargo.toml
+++ b/shinkai-libs/shinkai-message-primitives/Cargo.toml
@@ -23,7 +23,7 @@ base64 = { workspace = true }
 utoipa = "4.2.3"
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
-async-trait = "0.1.74"
+async-trait = { workspace = true }
 
 tracing = { version = "0.1.40", optional = true }
 


### PR DESCRIPTION
## Summary
- use workspace `rand` in http-api
- use workspace `tokio-util`, `uuid`, and `async-trait`
- unify `async-trait` usage across crates
- update lockfile

## Testing
- `cargo check -q`