### PR TITLE
Fix repeated dependency paths

### DIFF
--- a/shinkai-libs/shinkai-crypto-identities/Cargo.toml
+++ b/shinkai-libs/shinkai-crypto-identities/Cargo.toml
@@ -9,7 +9,7 @@ authors = { workspace = true }
 [dependencies]
 tokio = { workspace = true }
 serde_json = { workspace = true }
-shinkai_message_primitives = { path = "../shinkai-message-primitives" }
+shinkai_message_primitives = { workspace = true }
 x25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
 chrono = { workspace = true }

--- a/shinkai-libs/shinkai-tcp-relayer/Cargo.toml
+++ b/shinkai-libs/shinkai-tcp-relayer/Cargo.toml
@@ -10,8 +10,8 @@ authors = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
-shinkai_message_primitives = { path = "../shinkai-message-primitives" }
-shinkai_crypto_identities = { path = "../shinkai-crypto-identities" }
+shinkai_message_primitives = { workspace = true }
+shinkai_crypto_identities = { workspace = true }
 x25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
## Summary
- use workspace `shinkai_message_primitives` crate everywhere
- use workspace `shinkai_crypto_identities` crate in tcp relayer

## Testing
- `cargo check`