### PR TITLE
Remove unused chashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,16 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chashmap"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
-dependencies = [
- "owning_ref",
- "parking_lot 0.4.8",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,7 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -928,7 +918,7 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf 0.11.2",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -1252,7 +1242,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2",
  "subtle",
@@ -1434,12 +1424,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1642,8 +1626,8 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
- "smallvec 1.13.2",
+ "rand",
+ "smallvec",
  "spinning_top",
 ]
 
@@ -1935,7 +1919,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec 1.13.2",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -2081,7 +2065,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.13.2",
+ "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
@@ -2166,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec 1.13.2",
+ "smallvec",
  "utf8_iter",
 ]
 
@@ -2439,12 +2423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,7 +2487,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2541,7 +2519,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2793,25 +2771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "owning_ref"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
-dependencies = [
- "owning_ref",
- "parking_lot_core 0.2.14",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,18 +2793,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
-dependencies = [
- "libc",
- "rand 0.4.6",
- "smallvec 0.6.14",
- "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
@@ -2854,7 +2801,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec 1.13.2",
+ "smallvec",
  "winapi",
 ]
 
@@ -2867,7 +2814,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.5.7",
- "smallvec 1.13.2",
+ "smallvec",
  "windows-targets 0.52.6",
 ]
 
@@ -2966,7 +2913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2976,7 +2923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3264,7 +3211,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand 0.8.5",
+ "rand",
  "ring 0.17.8",
  "rustc-hash",
  "rustls 0.23.16",
@@ -3335,26 +3282,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3364,23 +3298,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3411,15 +3330,6 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3687,7 +3597,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -3734,7 +3644,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -4011,7 +3921,7 @@ dependencies = [
  "phf_codegen 0.10.0",
  "precomputed-hash",
  "servo_arc",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -4198,7 +4108,7 @@ dependencies = [
  "futures",
  "keyphrases",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest 0.11.27",
  "serde",
@@ -4221,7 +4131,7 @@ dependencies = [
  "keyphrases",
  "lazy_static",
  "os_path",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest 0.11.27",
  "scraper",
@@ -4253,7 +4163,7 @@ dependencies = [
  "futures",
  "hyper 0.14.31",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "reqwest 0.11.27",
  "rmcp",
  "rustls 0.20.9",
@@ -4302,7 +4212,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "os_path",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rust_decimal",
  "serde",
@@ -4330,7 +4240,6 @@ dependencies = [
  "bigdecimal",
  "bincode",
  "blake3",
- "chashmap",
  "chrono",
  "clap 3.2.25",
  "console-subscriber",
@@ -4351,7 +4260,7 @@ dependencies = [
  "open",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.8.5",
+ "rand",
  "rcgen",
  "regex",
  "reqwest 0.11.27",
@@ -4406,7 +4315,7 @@ dependencies = [
  "keyphrases",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.8.5",
+ "rand",
  "reqwest 0.11.27",
  "rusqlite",
  "rust_decimal",
@@ -4434,7 +4343,7 @@ dependencies = [
  "dotenv",
  "ed25519-dalek",
  "hex",
- "rand 0.8.5",
+ "rand",
  "serde_json",
  "shinkai_crypto_identities",
  "shinkai_message_primitives",
@@ -4516,7 +4425,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4560,15 +4469,6 @@ checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
 dependencies = [
  "deunicode",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
 ]
 
 [[package]]
@@ -5129,7 +5029,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -5205,7 +5105,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.13.2",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -5228,8 +5128,8 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
- "smallvec 1.13.2",
+ "rand",
+ "smallvec",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -5249,9 +5149,9 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "resolv-conf",
- "smallvec 1.13.2",
+ "smallvec",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -5276,7 +5176,7 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha-1",
  "thiserror 1.0.69",
  "url",
@@ -5295,7 +5195,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -5481,7 +5381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -5973,7 +5873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "zeroize",
 ]
@@ -6177,7 +6077,7 @@ dependencies = [
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "thiserror 2.0.3",
  "time",

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -32,7 +32,6 @@ warp = { workspace = true, features = ["compression-gzip"] }
 x25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
 rand = { workspace = true }
-chashmap = "2.2.2"
 async-channel = { workspace = true }
 lazy_static = { workspace = true }
 clap = { workspace = true }

--- a/shinkai-bin/shinkai-node/src/network/node.rs
+++ b/shinkai-bin/shinkai-node/src/network/node.rs
@@ -15,7 +15,7 @@ use crate::network::ws_routes::run_ws_api;
 use crate::wallet::coinbase_mpc_wallet::CoinbaseMPCWallet;
 use crate::wallet::wallet_manager::WalletManager;
 use async_channel::Receiver;
-use chashmap::CHashMap;
+use dashmap::DashMap;
 use chrono::Utc;
 use core::panic;
 use base64::Engine;
@@ -89,7 +89,7 @@ pub struct Node {
     // Secrets file path
     pub secrets_file_path: String,
     // A map of known peer nodes.
-    pub peers: CHashMap<(SocketAddr, ProfileName), chrono::DateTime<Utc>>,
+    pub peers: DashMap<(SocketAddr, ProfileName), chrono::DateTime<Utc>>,
     // The interval at which this node pings all known peers.
     pub ping_interval_secs: u64,
     // The channel from which this node receives commands.
@@ -382,7 +382,7 @@ impl Node {
             encryption_public_key,
             private_https_certificate,
             public_https_certificate,
-            peers: CHashMap::new(),
+            peers: DashMap::new(),
             listen_address,
             secrets_file_path,
             ping_interval_secs,

--- a/shinkai-bin/shinkai-node/src/network/v1_api/api_v1_internal_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v1_api/api_v1_internal_commands.rs
@@ -7,7 +7,7 @@ use crate::network::node_error::NodeError;
 use crate::network::Node;
 
 use async_channel::Sender;
-use chashmap::CHashMap;
+use dashmap::DashMap;
 use chrono::Utc;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use log::{error, info};
@@ -39,7 +39,7 @@ use x25519_dalek::{PublicKey as EncryptionPublicKey, StaticSecret as EncryptionS
 
 impl Node {
     pub async fn send_peer_addresses(
-        peers: CHashMap<(SocketAddr, String), chrono::DateTime<chrono::Utc>>,
+        peers: DashMap<(SocketAddr, String), chrono::DateTime<chrono::Utc>>,
         sender: Sender<Vec<SocketAddr>>,
     ) -> Result<(), Error> {
         let peer_addresses: Vec<SocketAddr> = peers.into_iter().map(|(k, _)| k.0).collect();
@@ -563,7 +563,7 @@ impl Node {
         node_name: ShinkaiName,
         encryption_secret_key: EncryptionStaticKey,
         identity_secret_key: SigningKey,
-        peers: CHashMap<(SocketAddr, String), chrono::DateTime<Utc>>,
+        peers: DashMap<(SocketAddr, String), chrono::DateTime<Utc>>,
         db: Arc<SqliteManager>,
         identity_manager: Arc<Mutex<IdentityManager>>,
         listen_address: SocketAddr,


### PR DESCRIPTION
## Summary
- speed up build by removing the `chashmap` dependency
- replace `CHashMap` usage with `DashMap`

## Testing
- `cargo check -q`
- `timeout 180 cargo test --workspace --all-targets --no-run --quiet` *(fails: failed to run custom build command for `utoipa-swagger-ui`)*
