### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/job_execution_core.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/job_execution_core.rs
@@ -57,7 +57,7 @@ impl JobManager {
 
         // Fetch data we need to execute job step
         let fetch_data_result = JobManager::fetch_relevant_job_data(&job_message.job_message.job_id, db.clone()).await;
-        let (mut full_job, llm_provider_found, _, user_profile) = match fetch_data_result {
+        let (full_job, llm_provider_found, _, user_profile) = match fetch_data_result {
             Ok(data) => data,
             Err(e) => return Self::handle_error(&db, None, &job_id, &identity_secret_key, e, ws_manager).await,
         };

--- a/shinkai-bin/shinkai-node/src/llm_provider/job_manager.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/job_manager.rs
@@ -475,7 +475,7 @@ impl JobManager {
                                     let agent_id = agent_name
                                         .get_agent_name_string()
                                         .ok_or(LLMProviderError::LLMProviderNotFound)?;
-                                    let mut job_creation: JobCreationInfo =
+                                    let job_creation: JobCreationInfo =
                                         serde_json::from_str(&data.message_raw_content)
                                             .map_err(|_| LLMProviderError::ContentParseFailed)?;
 

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/shared/deepseek_api.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/shared/deepseek_api.rs
@@ -75,8 +75,8 @@ pub fn deepseek_prepare_messages(
 mod tests {
     use super::*;
     use uuid::Uuid;
-    use serde_json::json;
-    use shinkai_message_primitives::schemas::llm_providers::serialized_llm_provider::{DeepSeek, SerializedLLMProvider};
+    
+    use shinkai_message_primitives::schemas::llm_providers::serialized_llm_provider::DeepSeek;
     use shinkai_message_primitives::schemas::subprompts::{SubPrompt, SubPromptType};
 
     #[test]

--- a/shinkai-bin/shinkai-node/src/managers/model_capabilities_manager_tests.rs
+++ b/shinkai-bin/shinkai-node/src/managers/model_capabilities_manager_tests.rs
@@ -8,7 +8,7 @@ mod tests {
 
     use crate::managers::model_capabilities_manager::ModelCapabilitiesManager;
 
-    use super::*;
+    
 
     // Helper function to convert a vector of ChatCompletionRequestMessage to a
     // single string

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/external_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/external_agent_offerings_manager.rs
@@ -240,7 +240,7 @@ impl ExtAgentOfferingsManager {
 
             let mut handles = Vec::new();
             loop {
-                let mut continue_immediately;
+                let continue_immediately;
 
                 // Get the jobs to process
                 let jobs_sorted = {

--- a/shinkai-bin/shinkai-node/src/network/network_manager/network_job_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/network_manager/network_job_manager.rs
@@ -210,7 +210,7 @@ impl NetworkJobManager {
 
             let mut handles = Vec::new();
             loop {
-                let mut continue_immediately;
+                let continue_immediately;
 
                 // Scope for acquiring and releasing the lock quickly
                 let job_ids_to_process: Vec<String> = {

--- a/shinkai-bin/shinkai-node/tests/it/db_inbox_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/db_inbox_tests.rs
@@ -1,12 +1,9 @@
 use shinkai_embedding::model_type::{EmbeddingModelType, OllamaTextEmbeddingsInference};
-use shinkai_message_primitives::schemas::identity::{StandardIdentity, StandardIdentityType};
 use shinkai_message_primitives::schemas::inbox_name::InboxName;
-use shinkai_message_primitives::schemas::inbox_permission::InboxPermission;
-use shinkai_message_primitives::schemas::shinkai_name::ShinkaiName;
 use shinkai_message_primitives::shinkai_message::shinkai_message::{
-    MessageBody, MessageData, ShinkaiMessage, ShinkaiVersion,
+    MessageBody, ShinkaiMessage,
 };
-use shinkai_message_primitives::shinkai_message::shinkai_message_schemas::{IdentityPermissions, MessageSchemaType};
+use shinkai_message_primitives::shinkai_message::shinkai_message_schemas::MessageSchemaType;
 use shinkai_message_primitives::shinkai_utils::encryption::{
     unsafe_deterministic_encryption_keypair, EncryptionMethod,
 };
@@ -14,7 +11,6 @@ use shinkai_message_primitives::shinkai_utils::shinkai_message_builder::ShinkaiM
 use shinkai_message_primitives::shinkai_utils::signatures::{
     clone_signature_secret_key, unsafe_deterministic_signature_keypair,
 };
-use shinkai_sqlite::errors::SqliteManagerError;
 use shinkai_sqlite::SqliteManager;
 
 use std::path::PathBuf;

--- a/shinkai-bin/shinkai-node/tests/it/node_integration_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/node_integration_tests.rs
@@ -1,5 +1,4 @@
 use async_channel::{bounded, Receiver, Sender};
-use core::panic;
 use shinkai_http_api::node_api_router::{APIError, SendResponseBodyData};
 use shinkai_http_api::node_commands::NodeCommand;
 use shinkai_message_primitives::shinkai_message::shinkai_message::ShinkaiMessage;

--- a/shinkai-bin/shinkai-node/tests/it/simple_job_example_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/simple_job_example_tests.rs
@@ -171,7 +171,7 @@ fn simple_job_message_test() {
                 .await;
             }
 
-            let mut job_id: String;
+            let job_id: String;
             let agent_subidentity = format!("{}/agent/{}", node1_profile_name, node1_agent);
 
             {

--- a/shinkai-bin/shinkai-node/tests/it/utils/node_test_api.rs
+++ b/shinkai-bin/shinkai-node/tests/it/utils/node_test_api.rs
@@ -7,11 +7,10 @@ use shinkai_http_api::node_commands::NodeCommand;
 use shinkai_message_primitives::schemas::identity::{Identity, IdentityType, StandardIdentity};
 use shinkai_message_primitives::schemas::llm_providers::serialized_llm_provider::SerializedLLMProvider;
 use shinkai_message_primitives::schemas::shinkai_name::ShinkaiName;
-use shinkai_message_primitives::schemas::smart_inbox::SmartInbox;
 use shinkai_message_primitives::shinkai_message::shinkai_message_schemas::{
     IdentityPermissions, MessageSchemaType, RegistrationCodeType
 };
-use shinkai_message_primitives::shinkai_utils::encryption::{encryption_public_key_to_string, EncryptionMethod};
+use shinkai_message_primitives::shinkai_utils::encryption::encryption_public_key_to_string;
 use shinkai_message_primitives::shinkai_utils::job_scope::MinimalJobScope;
 use shinkai_message_primitives::shinkai_utils::shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption};
 use shinkai_message_primitives::shinkai_utils::shinkai_message_builder::ShinkaiMessageBuilder;

--- a/shinkai-bin/shinkai-node/tests/it/utils/test_boilerplate.rs
+++ b/shinkai-bin/shinkai-node/tests/it/utils/test_boilerplate.rs
@@ -9,7 +9,6 @@ use shinkai_sqlite::SqliteManager;
 
 use tokio::sync::Mutex;
 
-use core::panic;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use futures::Future;
 use std::env;

--- a/shinkai-libs/shinkai-http-api/src/api_sse/mcp_tools_service.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_sse/mcp_tools_service.rs
@@ -356,7 +356,7 @@ impl ServerHandler for McpToolsService {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    
     
     // Add tests as needed
 } 

--- a/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/agent.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/llm_providers/agent.rs
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_agent_with_tools_config_override() {
-        use serde_json::{json, Map};
+        use serde_json::json;
         use std::collections::HashMap;
 
         // Create a test agent with tools_config_override

--- a/shinkai-libs/shinkai-sqlite/src/cron_task_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/cron_task_manager.rs
@@ -268,9 +268,7 @@ impl SqliteManager {
 mod tests {
     use super::*;
     use shinkai_embedding::model_type::{EmbeddingModelType, OllamaTextEmbeddingsInference};
-    use shinkai_message_primitives::{
-        shinkai_message::shinkai_message_schemas::JobMessage, shinkai_utils::shinkai_path::ShinkaiPath
-    };
+    use shinkai_message_primitives::shinkai_message::shinkai_message_schemas::JobMessage;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
 


### PR DESCRIPTION
I automatically removed unused imports using `cargo fix`.

This addresses many of the direct unused import warnings. However, a significant amount of dead code remains in the project, leading to "effectively" unused imports. Resolving the dead code is a larger, separate task.