### PR TITLE
Integrate x402 payment protocol (Phase 1)

### DIFF
--- a/shinkai-libs/shinkai-tools-primitives/src/tools/network_tool.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/network_tool.rs
@@ -13,7 +13,6 @@ pub struct NetworkTool {
     pub author: String,
     pub mcp_enabled: Option<bool>,
     pub provider: ShinkaiName,
-    pub usage_type: UsageType, // includes pricing
     pub activated: bool,
     pub config: Vec<ToolConfig>,
     pub input_args: Parameters,
@@ -21,6 +20,8 @@ pub struct NetworkTool {
     pub embedding: Option<Vec<f32>>,
     pub restrictions: Option<String>, // Could be a JSON string or a more structured type
                                       // ^ What was this for? I think it was *internal* user restrictions (e.g. max_requests_per_day, max_total_budget etc.)
+    pub payment_url: Option<String>,
+    pub facilitator_url: Option<String>,
 }
 // Asking Myself (AM): do we want transparency about knowing if it's a wrapped JSTool or Workflow?
 // TODO: add the same JS configuration to NetworkTool most likely we will use JSTool and Workflows (which is a subgroup)
@@ -32,13 +33,14 @@ impl NetworkTool {
         version: String,
         author: String,
         provider: ShinkaiName,
-        usage_type: UsageType,
         activated: bool,
         config: Vec<ToolConfig>,
         input_args: Parameters,
         output_arg: ToolOutputArg,
         embedding: Option<Vec<f32>>,
         restrictions: Option<String>,
+        payment_url: Option<String>,
+        facilitator_url: Option<String>,
     ) -> Self {
         Self {
             name,
@@ -46,7 +48,6 @@ impl NetworkTool {
             version,
             author,
             provider,
-            usage_type,
             activated,
             config,
             input_args,

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/shinkai_tool.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/shinkai_tool.rs
@@ -57,9 +57,8 @@ pub struct ShinkaiToolHeader {
     pub input_args: Parameters,
     pub output_arg: ToolOutputArg,
     pub config: Option<Vec<ToolConfig>>,
-    pub usage_type: Option<UsageType>, // includes pricing
-    // Note: do we need usage_type? it's already contained in the tool_offering
-    pub tool_offering: Option<ShinkaiToolOffering>,
+    pub payment_url: Option<String>,
+    pub facilitator_url: Option<String>,
 }
 
 impl ShinkaiToolHeader {
@@ -87,8 +86,14 @@ impl ShinkaiTool {
             input_args: self.input_args(),
             output_arg: self.output_arg(),
             config: self.get_js_tool_config().cloned(),
-            usage_type: self.get_usage_type(),
-            tool_offering: None,
+            payment_url: match self {
+                ShinkaiTool::Network(n, _) => n.payment_url.clone(),
+                _ => None,
+            },
+            facilitator_url: match self {
+                ShinkaiTool::Network(n, _) => n.facilitator_url.clone(),
+                _ => None,
+            },
         }
     }
 


### PR DESCRIPTION
This commit introduces the initial changes to replace the existing ShinkaiToolOffering mechanism with the x402 payment protocol.

Key changes include:

1.  Modified `NetworkTool` struct:
    *   Removed `usage_type`.
    *   Added `payment_url` and `facilitator_url` for x402.

2.  Updated `MyAgentOfferingsManager`:
    *   Adjusted `NetworkTool` instantiation.
    *   Removed functions tied to the old pricing model (`pay_invoice`, `verify_invoice`).
    *   Added placeholders in `network_request_invoice` for x402 flow.

3.  Updated `tool_router.rs`:
    *   Modified `add_testing_network_tools` for new `NetworkTool` structure.
    *   Updated `call_function`'s call to `network_request_invoice`.
    *   Commented out old invoice handling logic in `call_function` for `ShinkaiTool::Network` pending full x402 implementation.

4.  Updated Database Layer for Tool Registration/Discovery:
    *   Modified `ShinkaiToolHeader` to remove `usage_type` and `tool_offering`, and add `payment_url`, `facilitator_url`.
    *   Updated `shinkai_tool_manager.rs` to store these new fields for network tools and remove `on_demand_price`.
    *   Updated `lib.rs` (SQLite) to modify the `shinkai_tools` table schema (remove `on_demand_price`, add `payment_url`, `facilitator_url`) and include migration logic.