### PR TITLE
Remove Downloadable and Both UsageType variants

### DIFF
--- a/docs/openapi/tool_offerings.yaml
+++ b/docs/openapi/tool_offerings.yaml
@@ -252,26 +252,6 @@ components:
         properties:
           PerUse:
             $ref: '#/components/schemas/ToolPrice'
-      - type: object
-        required:
-        - Downloadable
-        properties:
-          Downloadable:
-            $ref: '#/components/schemas/ToolPrice'
-      - type: object
-        required:
-        - Both
-        properties:
-          Both:
-            type: object
-            required:
-            - per_use_price
-            - download_price
-            properties:
-              download_price:
-                $ref: '#/components/schemas/ToolPrice'
-              per_use_price:
-                $ref: '#/components/schemas/ToolPrice'
 tags:
 - name: tool_offerings
   description: Tool Offering API endpoints

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/external_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/external_agent_offerings_manager.rs
@@ -527,19 +527,9 @@ impl ExtAgentOfferingsManager {
         let usage_type = match invoice_request.usage_type_inquiry {
             UsageTypeInquiry::PerUse => match shinkai_offering.usage_type {
                 UsageType::PerUse(price) => UsageType::PerUse(price),
-                UsageType::Both { per_use_price, .. } => UsageType::PerUse(per_use_price),
                 _ => {
                     return Err(AgentOfferingManagerError::InvalidUsageType(
                         "Invalid usage type for PerUse inquiry".to_string(),
-                    ))
-                }
-            },
-            UsageTypeInquiry::Downloadable => match shinkai_offering.usage_type {
-                UsageType::Downloadable(price) => UsageType::Downloadable(price),
-                UsageType::Both { download_price, .. } => UsageType::Downloadable(download_price),
-                _ => {
-                    return Err(AgentOfferingManagerError::InvalidUsageType(
-                        "Invalid usage type for Downloadable inquiry".to_string(),
                     ))
                 }
             },

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
@@ -248,7 +248,7 @@ impl MyAgentOfferingsManager {
         })?;
 
         // Get the price for the usage type
-        let usage_type_inquiry = UsageTypeInquiry::PerUse; // or UsageTypeInquiry::Downloadable based on your context
+        let usage_type_inquiry = UsageTypeInquiry::PerUse;
         let price = invoice
             .shinkai_offering
             .get_price_for_usage(&usage_type_inquiry)

--- a/shinkai-libs/shinkai-message-primitives/src/schemas/shinkai_tool_offering.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/shinkai_tool_offering.rs
@@ -8,14 +8,12 @@ use super::wallet_mixed::Asset;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub enum UsageTypeInquiry {
     PerUse,
-    Downloadable,
 }
 
 impl fmt::Display for UsageTypeInquiry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             UsageTypeInquiry::PerUse => write!(f, "PerUse"),
-            UsageTypeInquiry::Downloadable => write!(f, "Downloadable"),
         }
     }
 }
@@ -31,9 +29,6 @@ impl ShinkaiToolOffering {
     pub fn get_price_for_usage(&self, usage_type_inquiry: &UsageTypeInquiry) -> Option<&ToolPrice> {
         match (usage_type_inquiry, &self.usage_type) {
             (UsageTypeInquiry::PerUse, UsageType::PerUse(price)) => Some(price),
-            (UsageTypeInquiry::Downloadable, UsageType::Downloadable(price)) => Some(price),
-            (UsageTypeInquiry::PerUse, UsageType::Both { per_use_price, .. }) => Some(per_use_price),
-            (UsageTypeInquiry::Downloadable, UsageType::Both { download_price, .. }) => Some(download_price),
             _ => None,
         }
     }
@@ -56,19 +51,12 @@ impl ShinkaiToolOffering {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum UsageType {
     PerUse(ToolPrice),
-    Downloadable(ToolPrice),
-    Both {
-        per_use_price: ToolPrice,
-        download_price: ToolPrice,
-    },
 }
 
 impl UsageType {
     pub fn per_use_usd_price(&self) -> f32 {
         match self {
             UsageType::PerUse(price) => price.to_usd_float(),
-            UsageType::Both { per_use_price, .. } => per_use_price.to_usd_float(),
-            _ => 0.0,
         }
     }
 }
@@ -127,18 +115,14 @@ mod tests {
     fn test_shinkai_tool_offering_to_json() {
         let offering = ShinkaiToolOffering {
             tool_key: "test_tool".to_string(),
-            usage_type: UsageType::Both {
-                per_use_price: ToolPrice::Free,
-                download_price: ToolPrice::DirectDelegation("1000".to_string()),
-            },
+            usage_type: UsageType::PerUse(ToolPrice::Free),
             meta_description: Some("A tool for testing".to_string()),
         };
 
         let json = serde_json::to_string(&offering).expect("Failed to convert to JSON");
         println!("{}", json);
         assert!(json.contains("\"tool_key\":\"test_tool\""));
-        assert!(json.contains("\"per_use_price\":\"Free\""));
-        assert!(json.contains("\"download_price\":{\"DirectDelegation\":\"1000\"}"));
+        assert!(json.contains("\"PerUse\":\"Free\""));
     }
 
     #[test]
@@ -147,12 +131,7 @@ mod tests {
         {
             "tool_key": "test_tool",
             "usage_type": {
-                "Both": {
-                    "per_use_price": "Free",
-                    "download_price": {
-                        "DirectDelegation": "1000"
-                    }
-                }
+                "PerUse": "Free"
             },
             "meta_description": "A tool for testing"
         }"#;
@@ -160,16 +139,7 @@ mod tests {
         let offering: ShinkaiToolOffering = serde_json::from_str(json).expect("Failed to convert from JSON");
         assert_eq!(offering.tool_key, "test_tool");
         assert_eq!(offering.meta_description, Some("A tool for testing".to_string()));
-        if let UsageType::Both {
-            per_use_price,
-            download_price,
-        } = offering.usage_type
-        {
-            assert_eq!(per_use_price, ToolPrice::Free);
-            assert_eq!(download_price, ToolPrice::DirectDelegation("1000".to_string()));
-        } else {
-            panic!("UsageType did not match expected value");
-        }
+        assert!(matches!(offering.usage_type, UsageType::PerUse(ToolPrice::Free)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- trim UsageType enum down to just `PerUse`
- clean up invoice handling logic
- update docs and tests for simpler usage type

## Testing
- `cargo check -p shinkai_message_primitives`
- `cargo check -p shinkai_node`
