### PR TITLE
Add x402 payment info to invoice API

### DIFF
--- a/docs/openapi/wallet.yaml
+++ b/docs/openapi/wallet.yaml
@@ -259,6 +259,9 @@ components:
         data_for_tool: {}
         invoice_id:
           type: string
+        x402_payment:
+          type: string
+          nullable: true
     RestoreCoinbaseMPCWalletRequest:
       type: object
       required:

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1436,6 +1436,7 @@ impl Node {
                 bearer,
                 invoice_id,
                 data_for_tool,
+                x402_payment,
                 res,
             } => {
                 let db_clone = Arc::clone(&self.db);
@@ -1448,6 +1449,7 @@ impl Node {
                         bearer,
                         invoice_id,
                         data_for_tool,
+                        x402_payment,
                         node_name,
                         res,
                     )

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_wallets.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_wallets.rs
@@ -143,6 +143,7 @@ pub async fn create_local_wallet_handler(
 pub struct PayInvoiceRequest {
     pub invoice_id: String,
     pub data_for_tool: Value,
+    pub x402_payment: Option<String>,
 }
 
 #[utoipa::path(
@@ -166,6 +167,7 @@ pub async fn pay_invoice_handler(
             bearer,
             invoice_id: payload.invoice_id,
             data_for_tool: payload.data_for_tool,
+            x402_payment: payload.x402_payment,
             res: res_sender,
         })
         .await

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -543,6 +543,7 @@ pub enum NodeCommand {
         bearer: String,
         invoice_id: String,
         data_for_tool: Value,
+        x402_payment: Option<String>,
         res: Sender<Result<Value, APIError>>,
     },
     V2ApiListInvoices {


### PR DESCRIPTION
## Summary
- extend `PayInvoiceRequest` with an optional `x402_payment` string
- include the payment in API routing and node commands
- return `InvalidOutput` details when invoice verification fails
- document the new field in OpenAPI docs

## Testing
- `cargo check -p shinkai_http_api`