### PR TITLE
Use payment nonce as invoice ID

### DIFF
--- a/shinkai-libs/shinkai-message-primitives/src/schemas/invoices.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/invoices.rs
@@ -1,11 +1,19 @@
 use std::{cmp::Ordering, fmt};
 
-use base64::Engine;
+use rand::RngCore;
 
 use chrono::{DateTime, Utc};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+/// Generates a random 32-byte nonce encoded as a hex string prefixed with `0x`.
+/// This mimics the nonce used by x402 payment requests and is used as the
+/// unique identifier for invoices.
+pub fn generate_x402_nonce() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("0x{}", hex::encode(bytes))
+}
 
 use super::{
     shinkai_name::ShinkaiName,
@@ -139,21 +147,11 @@ impl InternalInvoiceRequest {
         tool_key_name: String,
         usage_type_inquiry: UsageTypeInquiry,
     ) -> Self {
-        // Generate a random number
-        let random_number: u64 = rand::thread_rng().gen();
+        // Generate the unique invoice identifier using an x402-style nonce
+        let unique_id = generate_x402_nonce();
 
-        // Encode the random number in base64
-        let random_number_base64 =
-            base64::engine::general_purpose::STANDARD.encode(&random_number.to_be_bytes());
-
-        // Use only the first half of the base64 encoded string
-        let short_random_number = &random_number_base64[..random_number_base64.len() / 2];
-
-        // Combine the short random number and timestamp to create a unique ID
-        let unique_id = format!("{}", short_random_number);
-
-        // Generate a secret prehash value (example: using the tool_key_name and random number)
-        let secret_prehash = format!("{}{}", tool_key_name, random_number);
+        // Generate a secret prehash value (example: using the tool_key_name and nonce)
+        let secret_prehash = format!("{}{}", tool_key_name, unique_id);
 
         Self {
             provider_name: provider,


### PR DESCRIPTION
## Summary
- generate a 32-byte hex nonce for invoices
- use the nonce when creating `InternalInvoiceRequest`

## Testing
- `cargo check`