### PR TITLE
Add ngrok support for remote tunnels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,13 +269,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "awaitdrop"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771051cdc7eec2dc1b23fbf870bb7fbb89136fe374227c875e377f1eed99a429"
+dependencies = [
+ "futures",
+ "generational-arena",
+ "parking_lot 0.12.3",
+ "slotmap",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -303,6 +344,26 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -374,6 +435,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.87",
+ "which",
 ]
 
 [[package]]
@@ -560,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +719,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -707,6 +811,15 @@ name = "clap_lex"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -823,6 +936,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1192,6 +1315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1346,12 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1501,6 +1636,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls 0.23.16",
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1689,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1723,8 +1878,23 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "headers-core",
+ "headers-core 0.2.0",
  "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core 0.3.0",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1737,6 +1907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.12",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1789,6 +1968,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1925,6 +2124,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers 0.4.0",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +2154,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "rustls 0.23.16",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2295,10 +2515,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libloading"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libredox"
@@ -2408,6 +2644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2756,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "muxado"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe5ca6bbdcad071d41711c03946be52da5fb46bb42024e5d0d74e2fcefeab71"
+dependencies = [
+ "async-trait",
+ "awaitdrop",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "nanoid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,7 +2795,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2544,6 +2805,46 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "ngrok"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f28b76c1beb7392c760a3bfe5a854a51edbb2ddc789b10985114f10dc9f969"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "awaitdrop",
+ "axum-core 0.4.5",
+ "base64 0.21.7",
+ "bitflags 2.6.0",
+ "bytes",
+ "futures",
+ "futures-rustls",
+ "futures-util",
+ "hostname",
+ "hyper-http-proxy",
+ "hyper-util",
+ "muxado",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "proxy-protocol",
+ "regex",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-retry",
+ "tokio-socks",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "url",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "no-std-compat"
@@ -3068,6 +3369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,6 +3453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxy-protocol"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e50c72c21c738f5c5f350cc33640aee30bf7cd20f9d9da20ed41bce2671d532"
+dependencies = [
+ "bytes",
+ "snafu",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,7 +3516,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.16",
  "socket2",
  "thiserror 2.0.12",
@@ -3213,7 +3534,7 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.16",
  "rustls-pki-types",
  "slab",
@@ -3687,6 +4008,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -3758,12 +4085,39 @@ version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -3799,6 +4153,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -3918,7 +4273,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3926,9 +4294,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4287,6 +4655,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mockito",
+ "ngrok",
  "open",
  "r2d2",
  "r2d2_sqlite",
@@ -4313,6 +4682,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.15.0",
  "tokio-util",
+ "url",
  "urlencoding",
  "utoipa",
  "uuid",
@@ -4492,6 +4862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "slug"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,6 +4885,27 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "socket2"
@@ -4685,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -4873,9 +5273,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4902,9 +5302,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4918,6 +5318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -4951,6 +5362,18 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls 0.23.16",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -5012,6 +5435,7 @@ checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5499,7 +5923,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "headers",
+ "headers 0.3.9",
  "http 0.2.12",
  "hyper 0.14.31",
  "log",
@@ -5656,6 +6080,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.40",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5733,6 +6169,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5756,6 +6201,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5791,6 +6251,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5803,6 +6269,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5812,6 +6284,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5833,6 +6311,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5842,6 +6326,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5857,6 +6347,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5866,6 +6362,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -73,6 +73,8 @@ env_logger = { workspace = true }
 zip = "2.2.1"
 open = "5.3.2"
 sha2 = "0.10"
+ngrok = "0.15.0"
+url = "2.5.0"
 
 [dev-dependencies]
 mockito = "1.0.2"

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -2504,6 +2504,31 @@ impl Node {
                     let _ = Node::v2_api_get_last_used_agents_and_llms(db_clone, bearer, last, res).await;
                 });
             }
+            NodeCommand::V2ApiSetNgrokAuthToken { bearer, auth_token, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_set_ngrok_auth_token(db_clone, bearer, auth_token, res).await;
+                });
+            }
+            NodeCommand::V2ApiClearNgrokAuthToken { bearer, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_clear_ngrok_auth_token(db_clone, bearer, res).await;
+                });
+            }
+            NodeCommand::V2ApiSetNgrokEnabled { bearer, enabled, res } => {
+                let db_clone = Arc::clone(&self.db);
+                let node_env = fetch_node_environment();
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_set_ngrok_enabled(db_clone, bearer, enabled, node_env.api_listen_address, res).await;
+                });
+            }
+            NodeCommand::V2ApiGetNgrokStatus { bearer, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_get_ngrok_status(db_clone, bearer, res).await;
+                });
+            }
             _ => (),
         }
     }

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok.rs
@@ -155,12 +155,15 @@ impl Node {
             return Ok(());
         }
 
-        let status = db.read_ngrok_auth_token().unwrap();
+        let authtoken = db.read_ngrok_auth_token().unwrap();
+
+        let active_tunnel = ACTIVE_NGROK_TUNNEL.lock().await;
+        let tunnel = active_tunnel.as_ref().map(|t| t.url().to_string());
 
         let response = NgrokStatus {
-            enabled: status.is_some(),
-            tunnel: None,
-            authtoken: status,
+            enabled: authtoken.is_some(),
+            tunnel: tunnel,
+            authtoken: authtoken,
         };
 
         let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok.rs
@@ -1,0 +1,384 @@
+use crate::network::node_error::NodeError;
+use crate::network::Node;
+
+use async_channel::Sender;
+use reqwest::StatusCode;
+use serde::Serialize;
+use serde_json::Value;
+use shinkai_sqlite::SqliteManager;
+
+use std::sync::Arc;
+
+use lazy_static::lazy_static;
+use ngrok::{
+    self,
+    config::ForwarderBuilder,
+    forwarder::Forwarder,
+    tunnel::{EndpointInfo, HttpTunnel, TunnelCloser, TunnelInfo},
+    session::Session,
+};
+use shinkai_http_api::node_api_router::APIError;
+use tokio::sync::Mutex;
+use url::Url;
+
+// This will store the active ngrok tunnel, allowing it to persist.
+lazy_static! {
+    static ref ACTIVE_NGROK_SESSION: Mutex<Option<Session>> = Mutex::new(None);
+    static ref ACTIVE_NGROK_TUNNEL: Mutex<Option<Forwarder<HttpTunnel>>> = Mutex::new(None);
+}
+
+#[derive(Serialize)]
+pub struct NgrokStatus {
+    enabled: bool,
+    tunnel: Option<String>,
+    authtoken: Option<String>,
+}
+
+impl Node {
+    pub async fn v2_api_clear_ngrok_auth_token(
+        db: Arc<SqliteManager>,
+        bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        // Validate the bearer token
+        if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
+            return Ok(());
+        }
+
+        match db.read_ngrok_auth_token() {
+            Ok(Some(_)) => {
+                match db.set_ngrok_auth_token(None) {
+                    Ok(_) => {
+                        let response = NgrokStatus {
+                            enabled: false,
+                            tunnel: None,
+                            authtoken: None,
+                        };
+                        let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        let _ = res.send(Err(APIError::new(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to update ngrok auth token in DB",
+                            &e.to_string(),
+                        )))
+                        .await;
+                        return Ok(());
+                    }
+                }
+            }
+            Ok(None) => {
+                let _ = res.send(Err(APIError::new(
+                    StatusCode::BAD_REQUEST,
+                    "There is no ngrok auth token to clear",
+                    "",
+                )))
+                .await;
+                return Ok(());
+            }
+            Err(e) => {
+                let _ = res.send(Err(APIError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to read ngrok auth token from DB",
+                    &e.to_string(),
+                )))
+                .await;
+                return Ok(());
+            }
+        }
+    }
+
+    pub async fn v2_api_set_ngrok_auth_token(
+        db: Arc<SqliteManager>,
+        bearer: String,
+        auth_token: String,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        // Validate the bearer token
+        if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
+            return Ok(());
+        }
+
+        if auth_token.is_empty() {
+            let _ = res.send(Err(APIError::new(
+                StatusCode::BAD_REQUEST,
+                "Auth token is required",
+                "",
+            )))
+            .await;
+            return Ok(());
+        }
+
+        let mut active_tunnel = ACTIVE_NGROK_TUNNEL.lock().await;
+
+        if let Some(tunnel) = active_tunnel.take() {
+            let tunnel_url = tunnel.url().to_string();
+
+            let _ = res.send(Err(APIError::new(
+                StatusCode::BAD_REQUEST,
+                "Ngrok is already enabled",
+                &format!("Ngrok tunnel is already enabled: {}", tunnel_url),
+            )))
+            .await;
+            return Ok(());
+        }
+
+        if let Err(e) = db.set_ngrok_auth_token(Some(&auth_token)) {
+            let _ = res.send(Err(APIError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to update ngrok auth token in DB",
+                &e.to_string(),
+            )))
+            .await;
+            return Ok(());
+        }
+
+        let response = NgrokStatus {
+            enabled: false,
+            tunnel: None,
+            authtoken: Some(auth_token),
+        };
+
+        let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;
+
+        Ok(())
+    }
+
+    pub async fn v2_api_get_ngrok_status(
+        db: Arc<SqliteManager>,
+        bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        // Validate the bearer token
+        if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
+            return Ok(());
+        }
+
+        let status = db.read_ngrok_auth_token().unwrap();
+
+        let response = NgrokStatus {
+            enabled: status.is_some(),
+            tunnel: None,
+            authtoken: status,
+        };
+
+        let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;
+
+        Ok(())
+    }
+
+    pub async fn v2_api_set_ngrok_enabled(
+        db: Arc<SqliteManager>,
+        bearer: String,
+        enabled: bool,
+        api_listen_address: std::net::SocketAddr,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        // Validate the bearer token
+        if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
+            return Ok(());
+        }
+
+        let mut active_tunnel_guard = ACTIVE_NGROK_TUNNEL.lock().await;
+
+        if enabled {
+            // If there's an existing tunnel, report its status and return.
+            if let Some(ref existing_tunnel) = *active_tunnel_guard {
+                let tunnel_url = existing_tunnel.url().to_string();
+                let authtoken_for_status = match db.read_ngrok_auth_token() {
+                    Ok(token_opt) => token_opt,
+                    Err(e) => {
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                            shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                            shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+                            &format!("Failed to read ngrok auth token for status (tunnel already active): {}", e),
+                        );
+                        None // If error reading, report as None for status
+                    }
+                };
+                let response = NgrokStatus {
+                    enabled: true,
+                    tunnel: Some(tunnel_url),
+                    authtoken: authtoken_for_status,
+                };
+                let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;
+                return Ok(());
+            }
+
+            // No existing tunnel, proceed to create one.
+            // First, get the auth token from DB. This is crucial for creating a new session if needed.
+            let auth_token_from_db = match db.read_ngrok_auth_token() {
+                Ok(token_opt) => token_opt,
+                Err(e) => {
+                    let _ = res.send(Err(APIError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to read ngrok auth token from DB before starting tunnel",
+                        &e.to_string(),
+                    ))).await;
+                    return Ok(());
+                }
+            };
+
+            // Session Management: Get or create an ngrok session
+            let session_for_tunnel_creation: Session;
+            { // Scoped to manage the lock on ACTIVE_NGROK_SESSION
+                let active_ngrok_session_guard = ACTIVE_NGROK_SESSION.lock().await;
+                if let Some(cached_session) = active_ngrok_session_guard.as_ref() {
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+                        &format!("Reusing existing ngrok session: {}", cached_session.id()),
+                    );
+                    session_for_tunnel_creation = cached_session.clone();
+                    // active_ngrok_session_guard lock is released when it goes out of scope here
+                } else {
+                    // No cached session, so release the lock before .await for connect()
+                    drop(active_ngrok_session_guard);
+
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+                        "No existing ngrok session found, creating a new one.",
+                    );
+
+                    // An auth token is required to create a new session.
+                    let token_for_new_session = match &auth_token_from_db {
+                        Some(token) => token.clone(),
+                        None => {
+                            let _ = res.send(Err(APIError::new(
+                                StatusCode::BAD_REQUEST,
+                                "Ngrok auth token is required to create a new ngrok session, but no token is set.",
+                                "Please set the ngrok auth token first via the API.",
+                            ))).await;
+                            return Ok(());
+                        }
+                    };
+
+                    let new_session = match ngrok::Session::builder()
+                        .authtoken(token_for_new_session)
+                        .connect()
+                        .await
+                    {
+                        Ok(session) => session,
+                        Err(e) => {
+                            let _ = res.send(Err(APIError::new(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "Failed to connect to ngrok to establish a new session",
+                                &e.to_string(),
+                            ))).await;
+                            return Ok(());
+                        }
+                    };
+                    
+                    // Re-acquire lock to store the new session globally
+                    let mut active_ngrok_session_guard_for_storing = ACTIVE_NGROK_SESSION.lock().await;
+                    *active_ngrok_session_guard_for_storing = Some(new_session.clone());
+                    session_for_tunnel_creation = new_session;
+                    // active_ngrok_session_guard_for_storing lock is released when it goes out of scope here
+                }
+            } // End of scope for locks on ACTIVE_NGROK_SESSION
+
+            let to_url = match Url::parse(&format!("http://{}:{}", api_listen_address.ip(), api_listen_address.port())) { // TODO: Make port configurable
+                Ok(url) => url,
+                Err(e) => {
+                    let _ = res.send(Err(APIError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to parse ngrok target URL",
+                        &e.to_string(),
+                    ))).await;
+                    return Ok(());
+                }
+            };
+
+            let ngrok_tunnel = match session_for_tunnel_creation
+                .http_endpoint()
+                .metadata("Shinkai Node")
+                .listen_and_forward(to_url)
+                .await
+            {
+                Ok(tunnel) => tunnel,
+                Err(e) => {
+                    let _ = res.send(Err(APIError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to start ngrok tunnel",
+                        &e.to_string(),
+                    ))).await;
+                    return Ok(());
+                }
+            };
+
+            let tunnel_url = ngrok_tunnel.url().to_string();
+            shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+                &format!(
+                    "NGROK Tunnel Started: {} (id: {})",
+                    tunnel_url,
+                    ngrok_tunnel.id()
+                ),
+            );
+
+            // Store the tunnel in the static variable.
+            *active_tunnel_guard = Some(ngrok_tunnel);
+
+            let response = NgrokStatus {
+                enabled, // true
+                tunnel: Some(tunnel_url),
+                authtoken: auth_token_from_db.clone(), // auth_token_from_db is Option<String>
+            };
+            let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;
+        } else {
+            // Disabling ngrok
+            if let Some(mut tunnel_to_close) = active_tunnel_guard.take() {
+                shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+                    &format!("Closing ngrok tunnel: {}", tunnel_to_close.id()),
+                );
+                if let Err(e) = tunnel_to_close.close().await {
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Error,
+                        &format!("Failed to close ngrok tunnel: {}", e),
+                    );
+                    // Send error to client
+                    let _ = res.send(Err(APIError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to close ngrok tunnel",
+                        &e.to_string(),
+                    ))).await;
+                    // The original code proceeded to send a status update.
+                    // Depending on desired behavior, one might return early here.
+                    // For now, matching original behavior of still sending status.
+                }
+            } else {
+                shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+                    "No active ngrok tunnel found to disable.",
+                );
+            }
+
+            let authtoken_for_status = match db.read_ngrok_auth_token() {
+                Ok(token_opt) => token_opt,
+                Err(e) => {
+                    shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Node,
+                        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Error,
+                        &format!("Failed to read ngrok auth token from DB for status when disabling: {}", e),
+                    );
+                    None 
+                }
+            };
+            let response = NgrokStatus {
+                enabled, // false
+                tunnel: None,
+                authtoken: authtoken_for_status,
+            };
+            let _ = res.send(Ok(serde_json::to_value(response).unwrap())).await;
+        }
+
+        Ok(())
+    }
+}

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok.rs
@@ -161,7 +161,7 @@ impl Node {
         let tunnel = active_tunnel.as_ref().map(|t| t.url().to_string());
 
         let response = NgrokStatus {
-            enabled: authtoken.is_some(),
+            enabled: tunnel.is_some(),
             tunnel: tunnel,
             authtoken: authtoken,
         };

--- a/shinkai-bin/shinkai-node/src/network/v2_api/mod.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/mod.rs
@@ -4,6 +4,7 @@ pub mod api_v2_commands_ext_agent_offers;
 pub mod api_v2_commands_jobs;
 pub mod api_v2_commands_my_agent_offers;
 pub mod api_v2_commands_oauth;
+pub mod api_v2_commands_ngrok;
 pub mod api_v2_commands_prompts;
 pub mod api_v2_commands_tools;
 pub mod api_v2_commands_vecfs;

--- a/shinkai-bin/shinkai-node/src/runner.rs
+++ b/shinkai-bin/shinkai-node/src/runner.rs
@@ -217,11 +217,13 @@ pub async fn initialize_node() -> Result<
     // Setup API Server task
     let api_listen_address = node_env.clone().api_listen_address;
     let api_https_listen_address = node_env.clone().api_https_listen_address;
+    let ws_listen_address = node_env.clone().ws_address.unwrap();
     let api_server = tokio::spawn(async move {
         if let Err(e) = node_api_router::run_api(
             node_commands_sender,
             api_listen_address,
             api_https_listen_address,
+            ws_listen_address,
             global_identity_name.clone().to_string(),
             node_keys.private_https_certificate.clone(),
             node_keys.public_https_certificate.clone(),

--- a/shinkai-bin/shinkai-node/tests/it/tool_config_override_test.rs
+++ b/shinkai-bin/shinkai-node/tests/it/tool_config_override_test.rs
@@ -149,9 +149,11 @@ fn test_tool_execution_with_config_override() {
         // Create node1 and node2
         assert!(port_is_available(9570), "Port 9570 is not available");
         assert!(port_is_available(9560), "Port 9560 is not available");
+        assert!(port_is_available(9580), "Port 9580 is not available");
         // Setup API Server task
         let api_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9570);
         let api_https_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9560);
+        let ws_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9580);
 
         let node1_commands_sender_clone = node1_commands_sender.clone();
         let api_server = tokio::spawn(async move {
@@ -159,6 +161,7 @@ fn test_tool_execution_with_config_override() {
                 node1_commands_sender_clone,
                 api_listen_address,
                 api_https_listen_address,
+                ws_listen_address,
                 node1_identity_name.to_string(),
                 None,
                 None,

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ngrok.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ngrok.rs
@@ -1,0 +1,200 @@
+use async_channel::Sender;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use utoipa::ToSchema;
+use warp::Filter;
+
+use super::api_v2_router::{create_success_response, with_sender};
+use crate::node_commands::NodeCommand;
+
+#[derive(Deserialize, ToSchema)]
+pub struct SetNgrokAuthTokenRequest {
+    pub auth_token: String,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct SetNgrokEnabledRequest {
+    pub enabled: bool,
+}
+
+pub fn ngrok_routes(
+    node_commands_sender: Sender<NodeCommand>,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    let set_auth_token_route = warp::path("set_ngrok_auth_token")
+        .and(warp::post())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json())
+        .and_then(set_ngrok_auth_token_handler);
+
+    let clear_auth_token_route = warp::path("clear_ngrok_auth_token")
+        .and(warp::post())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and_then(clear_ngrok_auth_token_handler);
+
+    let set_enabled_route = warp::path("set_ngrok_enabled")
+        .and(warp::post())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json())
+        .and_then(set_ngrok_enabled_handler);
+
+    let get_status_route = warp::path("get_ngrok_status")
+        .and(warp::get())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and_then(get_ngrok_status_handler);
+
+    set_auth_token_route
+        .or(clear_auth_token_route)
+        .or(set_enabled_route)
+        .or(get_status_route)
+}
+
+#[utoipa::path(
+    post,
+    path = "/v2/set_ngrok_auth_token",
+    request_body = SetNgrokAuthTokenRequest,
+    responses(
+        (status = 200, description = "Successfully set ngrok auth token", body = Value),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError)
+    )
+)]
+pub async fn set_ngrok_auth_token_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+    payload: SetNgrokAuthTokenRequest,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    shinkai_message_primitives::shinkai_utils::shinkai_logging::shinkai_log(
+        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogOption::Api,
+        shinkai_message_primitives::shinkai_utils::shinkai_logging::ShinkaiLogLevel::Info,
+        &format!("Setting ngrok auth token: {}", payload.auth_token),
+    );
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiSetNgrokAuthToken {
+            bearer,
+            auth_token: payload.auth_token,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
+        }
+        Err(error) => Err(warp::reject::custom(error)),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v2/clear_ngrok_auth_token",
+    responses(
+        (status = 200, description = "Successfully cleared ngrok auth token", body = Value),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError)
+    )
+)]
+pub async fn clear_ngrok_auth_token_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiClearNgrokAuthToken {
+            bearer,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
+        }
+        Err(error) => Err(warp::reject::custom(error)),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v2/set_ngrok_enabled",
+    request_body = SetNgrokEnabledRequest,
+    responses(
+        (status = 200, description = "Successfully set ngrok enabled state", body = Value),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError)
+    )
+)]
+pub async fn set_ngrok_enabled_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+    payload: SetNgrokEnabledRequest,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiSetNgrokEnabled {
+            bearer,
+            enabled: payload.enabled,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
+        }
+        Err(error) => Ok(warp::reply::with_status(
+            warp::reply::json(&error),
+            StatusCode::from_u16(error.code).unwrap(),
+        )),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v2/get_ngrok_status",
+    responses(
+        (status = 200, description = "Successfully got ngrok status", body = Value),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError)
+    )
+)]
+pub async fn get_ngrok_status_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiGetNgrokStatus { bearer, res: res_sender })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
+        }
+        Err(error) => Err(warp::reject::custom(error)),
+    }
+}

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ngrok.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ngrok.rs
@@ -169,7 +169,7 @@ pub async fn set_ngrok_enabled_handler(
 }
 
 #[utoipa::path(
-    post,
+    get,
     path = "/v2/get_ngrok_status",
     responses(
         (status = 200, description = "Successfully got ngrok status", body = Value),

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_router.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_router.rs
@@ -10,6 +10,7 @@ use super::api_v2_handlers_swagger_ui::swagger_ui_routes;
 use super::api_v2_handlers_tools::tool_routes;
 use super::api_v2_handlers_vecfs::vecfs_routes;
 use super::api_v2_handlers_wallets::wallet_routes;
+use super::api_v2_handlers_ngrok::ngrok_routes;
 use async_channel::Sender;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -30,6 +31,7 @@ pub fn v2_routes(
     let tool_routes = tool_routes(node_commands_sender.clone());
     let cron_routes = cron_routes(node_commands_sender.clone(), node_name.clone());
     let oauth_routes = oauth_routes(node_commands_sender.clone());
+    let ngrok_routes = ngrok_routes(node_commands_sender.clone());
 
     general_routes
         .or(vecfs_routes)
@@ -41,6 +43,7 @@ pub fn v2_routes(
         .or(tool_routes)
         .or(cron_routes)
         .or(oauth_routes)
+        .or(ngrok_routes)
 }
 
 pub fn with_sender(

--- a/shinkai-libs/shinkai-http-api/src/api_v2/mod.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/mod.rs
@@ -9,4 +9,5 @@ pub mod api_v2_handlers_swagger_ui;
 pub mod api_v2_handlers_tools;
 pub mod api_v2_handlers_vecfs;
 pub mod api_v2_handlers_wallets;
+pub mod api_v2_handlers_ngrok;
 pub mod api_v2_router;

--- a/shinkai-libs/shinkai-http-api/src/api_ws/api_ws_handlers.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_ws/api_ws_handlers.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 use warp::filters::ws::{Message, WebSocket};
 use shinkai_message_primitives::shinkai_utils::shinkai_logging::{shinkai_log, ShinkaiLogLevel, ShinkaiLogOption};
-use std::env;
 use tokio::sync::Mutex;
 use futures::{StreamExt, SinkExt};
 use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 use bytes::Bytes;
 
 pub async fn ws_handler(
-    ws: WebSocket
+    ws: WebSocket,
+    ws_address: std::net::SocketAddr,
 ) {
     // Get the target WebSocket server URL
-    let target_url = format!("ws://localhost:{}/ws", env::var("NODE_WS_PORT").unwrap_or_else(|_| "9551".to_string()));
+    let target_url = format!("ws://{}:{}/ws", ws_address.ip(), ws_address.port());
     
     // Connect to the target WebSocket server
     match tokio_tungstenite::connect_async(target_url).await {

--- a/shinkai-libs/shinkai-http-api/src/api_ws/api_ws_routes.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_ws/api_ws_routes.rs
@@ -25,14 +25,14 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Rejection> {
 }
 
 /// Create the Warp routes for WebSocket endpoints
-pub fn ws_routes() -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+pub fn ws_routes(ws_address: std::net::SocketAddr) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     tracing::info!("Setting up WebSocket routes");
 
     let root_ws = warp::path::end()
         .and(warp::ws())
         .map(move |ws| {
             let ws: warp::ws::Ws = ws;
-            ws.on_upgrade(move |socket| ws_handler(socket))
+            ws.on_upgrade(move |socket| ws_handler(socket, ws_address))
         });
 
     root_ws

--- a/shinkai-libs/shinkai-http-api/src/node_api_router.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_api_router.rs
@@ -104,6 +104,7 @@ pub async fn run_api(
     node_commands_sender: Sender<NodeCommand>,
     address: SocketAddr,
     https_address: SocketAddr,
+    ws_address: SocketAddr,
     node_name: String,
     private_https_certificate: Option<String>,
     public_https_certificate: Option<String>,
@@ -156,7 +157,7 @@ pub async fn run_api(
     );
 
     let ws_routes = warp::path("ws").and(
-        api_ws::api_ws_routes::ws_routes()
+        api_ws::api_ws_routes::ws_routes(ws_address)
             .recover(handle_rejection)
             .with(log)
             .with(cors.clone()),

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -1012,4 +1012,22 @@ pub enum NodeCommand {
         tool_router_key: String,
         res: Sender<Result<Value, APIError>>,
     },
+    V2ApiSetNgrokAuthToken {
+        bearer: String,
+        auth_token: String,
+        res: Sender<Result<Value, APIError>>,
+    },
+    V2ApiClearNgrokAuthToken {
+        bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    },
+    V2ApiSetNgrokEnabled {
+        bearer: String,
+        enabled: bool,
+        res: Sender<Result<Value, APIError>>,
+    },
+    V2ApiGetNgrokStatus {
+        bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    },
 }

--- a/shinkai-libs/shinkai-sqlite/src/settings_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/settings_manager.rs
@@ -58,6 +58,29 @@ impl SqliteManager {
 
         Ok(key)
     }
+
+    pub fn set_ngrok_auth_token(&self, auth_token: Option<&str>) -> Result<(), SqliteManagerError> {
+        let conn = self.get_connection()?;
+
+        if let Some(auth_token) = auth_token {
+            let mut stmt = conn.prepare("INSERT OR REPLACE INTO shinkai_settings (key, value) VALUES ('ngrok_auth_token', ?)")?;
+            stmt.execute([auth_token])?;
+        } else {
+            let mut stmt = conn.prepare("DELETE FROM shinkai_settings WHERE key = 'ngrok_auth_token'")?;
+            stmt.execute([])?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read_ngrok_auth_token(&self) -> Result<Option<String>, SqliteManagerError> {
+        let conn = self.get_connection()?;
+        let stmt = conn.prepare("SELECT value FROM shinkai_settings WHERE key = 'ngrok_auth_token'");
+
+        let auth_token = stmt?.query_row([], |row| row.get(0)).ok();
+
+        Ok(auth_token)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Create 4 new endpoints to interact with ngrok to set a tunnel to the Shinkai node API server:

**POST /v2/set_ngrok_auth_token:**
- Sets the Ngrok authentication token.
- Accepts a JSON request body with an auth_token field (string).

**POST /v2/clear_ngrok_auth_token:**
- Clears the currently configured Ngrok authentication token.
- Does not require a request body.

**POST /v2/set_ngrok_enabled:**
- Enables or disables Ngrok tunnel.
- Accepts a JSON request body with an enabled field (boolean).
- If successful returns the tunnel URL if enabled, or removes the tunnel if disabled.
- 
**GET /v2/get_ngrok_status:**
- Retrieves the current Ngrok status (e.g., if it's enabled, and potentially other relevant information).
- Does not require a request body.