### PR TITLE
fix: initialiation issues 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,7 +4110,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shinkai_crypto_identities"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_embedding"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_fs"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_http_api"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_job_queue_manager"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "chrono",
  "serde",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_message_primitives"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_node"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_non_rust_code"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_sqlite"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_tcp_relayer"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "chrono",
  "clap 3.2.25",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "shinkai_tools_primitives"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 authors = ["Nico Arqueros <nico@shinkai.com>"]
 

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands.rs
@@ -772,11 +772,6 @@ impl Node {
                 return Ok(());
             }
         };
-        let docker_status = match shinkai_tools_runner::tools::container_utils::is_docker_available() {
-            shinkai_tools_runner::tools::container_utils::DockerStatus::NotInstalled => "not-installed",
-            shinkai_tools_runner::tools::container_utils::DockerStatus::NotRunning => "not-running",
-            shinkai_tools_runner::tools::container_utils::DockerStatus::Running => "running",
-        };
 
         let _ = res
             .send(Ok(serde_json::json!({
@@ -784,7 +779,7 @@ impl Node {
                 "public_https_certificate": public_https_certificate,
                 "version": version,
                 "update_requires_reset": needs_global_reset,
-                "docker_status": docker_status,
+                "docker_status": "not-installed",
             })))
             .await;
         Ok(())


### PR DESCRIPTION
- failing initialization when the proxy identity name is wrong
- failing initialization (from the app pov) when use "low" specs machines having docker installed. As a workaround docker status was replaced by a placeholder in the healthcheck endpoint. Later we will need to create a dedicated endpoint just to check docker.