### PR TITLE
Handle MCP command from smithery

### DIFF
--- a/shinkai-bin/shinkai-node/src/utils/github_mcp.rs
+++ b/shinkai-bin/shinkai-node/src/utils/github_mcp.rs
@@ -1,8 +1,8 @@
 use log::info;
 use regex::Regex;
 use reqwest::Client;
-use std::collections::HashSet;
 use serde_yaml::Value as YamlValue;
+use std::collections::HashSet;
 
 /// GitHub repository information
 pub struct GitHubRepo {
@@ -205,10 +205,7 @@ pub fn extract_start_command_from_smithery_yaml(yaml_content: &str) -> Option<St
         if let Some(start_cmd) = yaml.get("startCommand") {
             if let Some(cmd_fn) = start_cmd.get("commandFunction") {
                 if let Some(fn_str) = cmd_fn.as_str() {
-                    let re = Regex::new(
-                        r"command:\s*['\"](?P<cmd>[^'\"]+)['\"].*?args:\s*\[(?P<args>[^\]]*)\]",
-                    )
-                    .ok()?;
+                    let re = Regex::new(r#"command:\s*['"](?P<cmd>[^'"]+)['"].*?args:\s*\[(?P<args>[^\]]*)\]"#).ok()?;
 
                     if let Some(caps) = re.captures(fn_str) {
                         let cmd = caps.name("cmd")?.as_str();


### PR DESCRIPTION
## Summary
- parse smithery.yaml to pull out start commands
- detect python-based commands and switch to `uvx` using package hints from README
- add helpers for extracting command and package names
- update tests

## Testing
- `IS_TESTING=1 cargo test --lib --tests -- --test-threads=1` *(fails: curl download file exited with error status: exit status: 7)*