### PR TITLE
Add ngrok feature flag

### DIFF
--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -10,9 +10,12 @@ default-run = "shinkai_node"
 [build-dependencies]
 shinkai_tools_runner = { workspace = true, features = ["built-in-tools"] }
 
+# Features
 [features]
 default = []
 console = ["console-subscriber"]
+# Enable ngrok support when the `ngrok` feature is selected
+ngrok = ["dep:ngrok"]
 # static-pdf-parser = ["shinkai_vector_resources/static-pdf-parser"]
 
 [lib]
@@ -86,7 +89,7 @@ zip = "2.2.1"
 open = "5.3.2"
 sha2 = "0.10"
 toml = "0.8.22"
-ngrok = { version = "0.15.0", features = ["hyper"] }
+ngrok = { version = "0.15.0", features = ["hyper"], optional = true }
 url = "2.5.0"
 serde_yaml = { workspace = true }
 

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok_disabled.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ngrok_disabled.rs
@@ -1,0 +1,73 @@
+use crate::network::node_error::NodeError;
+use crate::network::Node;
+use async_channel::Sender;
+use reqwest::StatusCode;
+use serde_json::Value;
+use shinkai_sqlite::SqliteManager;
+use shinkai_http_api::node_api_router::APIError;
+use std::sync::Arc;
+
+impl Node {
+    pub async fn v2_api_clear_ngrok_auth_token(
+        _db: Arc<SqliteManager>,
+        _bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        let _ = res
+            .send(Err(APIError::new(
+                StatusCode::NOT_IMPLEMENTED,
+                "Not Implemented",
+                "Ngrok feature is disabled",
+            )))
+            .await;
+        Ok(())
+    }
+
+    pub async fn v2_api_set_ngrok_auth_token(
+        _db: Arc<SqliteManager>,
+        _bearer: String,
+        _auth_token: String,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        let _ = res
+            .send(Err(APIError::new(
+                StatusCode::NOT_IMPLEMENTED,
+                "Not Implemented",
+                "Ngrok feature is disabled",
+            )))
+            .await;
+        Ok(())
+    }
+
+    pub async fn v2_api_get_ngrok_status(
+        _db: Arc<SqliteManager>,
+        _bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        let _ = res
+            .send(Err(APIError::new(
+                StatusCode::NOT_IMPLEMENTED,
+                "Not Implemented",
+                "Ngrok feature is disabled",
+            )))
+            .await;
+        Ok(())
+    }
+
+    pub async fn v2_api_set_ngrok_enabled(
+        _db: Arc<SqliteManager>,
+        _bearer: String,
+        _enabled: bool,
+        _api_listen_address: std::net::SocketAddr,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        let _ = res
+            .send(Err(APIError::new(
+                StatusCode::NOT_IMPLEMENTED,
+                "Not Implemented",
+                "Ngrok feature is disabled",
+            )))
+            .await;
+        Ok(())
+    }
+}

--- a/shinkai-bin/shinkai-node/src/network/v2_api/mod.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/mod.rs
@@ -3,12 +3,17 @@ pub mod api_v2_commands_cron;
 pub mod api_v2_commands_ext_agent_offers;
 pub mod api_v2_commands_jobs;
 pub mod api_v2_commands_my_agent_offers;
-pub mod api_v2_commands_oauth;
 #[cfg(feature = "ngrok")]
 pub mod api_v2_commands_ngrok;
 #[cfg(not(feature = "ngrok"))]
-pub mod api_v2_commands_ngrok_disabled as api_v2_commands_ngrok;
+pub mod api_v2_commands_ngrok_disabled;
+pub mod api_v2_commands_oauth;
 pub mod api_v2_commands_prompts;
 pub mod api_v2_commands_tools;
 pub mod api_v2_commands_vecfs;
 pub mod api_v2_commands_wallets;
+
+#[cfg(feature = "ngrok")]
+pub use api_v2_commands_ngrok;
+#[cfg(not(feature = "ngrok"))]
+pub use api_v2_commands_ngrok_disabled as api_v2_commands_ngrok;

--- a/shinkai-bin/shinkai-node/src/network/v2_api/mod.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/mod.rs
@@ -4,7 +4,10 @@ pub mod api_v2_commands_ext_agent_offers;
 pub mod api_v2_commands_jobs;
 pub mod api_v2_commands_my_agent_offers;
 pub mod api_v2_commands_oauth;
+#[cfg(feature = "ngrok")]
 pub mod api_v2_commands_ngrok;
+#[cfg(not(feature = "ngrok"))]
+pub mod api_v2_commands_ngrok_disabled as api_v2_commands_ngrok;
 pub mod api_v2_commands_prompts;
 pub mod api_v2_commands_tools;
 pub mod api_v2_commands_vecfs;


### PR DESCRIPTION
## Summary
- allow compiling `shinkai_node` without ngrok
- implement stub API when ngrok is disabled

## Testing
- `cargo test --workspace --quiet` *(fails: curl download for utoipa-swagger-ui)*

------
https://chatgpt.com/codex/tasks/task_e_683b690578c8832186ad61fed7e8b1dc