### PR TITLE
Use workspace rmcp dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ shinkai_fs = { path = "./shinkai-libs/shinkai-fs" }
 shinkai_embedding = { path = "./shinkai-libs/shinkai-embedding" }
 shinkai_non_rust_code = { path = "./shinkai-libs/shinkai-non-rust-code" }
 shinkai_mcp = { path = "./shinkai-libs/shinkai-mcp" }
+rmcp = "0.1.5"
 
 futures = "0.3.30"
 keyphrases = "0.3.3"

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -38,7 +38,7 @@ clap = { workspace = true }
 regex = { workspace = true }
 csv = { workspace = true }
 once_cell = "1.19.0"
-rmcp = { version = "0.1.5", features = [
+rmcp = { workspace = true, features = [
     "transport-child-process",
     "client",
     "transport-sse",

--- a/shinkai-libs/shinkai-http-api/Cargo.toml
+++ b/shinkai-libs/shinkai-http-api/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { workspace = true, features = ["v4"] }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.18"
 anyhow = { workspace = true }
-rmcp = { version = "0.1", features = ["server", "macros"] }
+rmcp = { workspace = true, features = ["server", "macros"] }
 tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 
 [dependencies.serde]

--- a/shinkai-libs/shinkai-mcp/Cargo.toml
+++ b/shinkai-libs/shinkai-mcp/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-rmcp = { version = "0.1", features = [
+rmcp = { workspace = true, features = [
     "client",
     "transport-child-process",
     "transport-sse",

--- a/shinkai-libs/shinkai-tools-primitives/Cargo.toml
+++ b/shinkai-libs/shinkai-tools-primitives/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 shinkai_tools_runner = { workspace = true, features = ["built-in-tools"] }
 serde = { workspace = true, features = ["derive"] }
 base64 = { workspace = true }
-rmcp = { version = "0.1", features = ["client", "transport-child-process", "transport-sse"] }
+rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-sse"] }
 log = { workspace = true }
 once_cell = "1.19"
 shinkai_mcp = { workspace = true }


### PR DESCRIPTION
## Summary
- define `rmcp` version in workspace dependencies
- reference workspace rmcp from dependent crates

## Testing
- `cargo check`
- `IS_TESTING=1 cargo test -- --test-threads=1` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683b768066a88321acad4b743dfd204f