### PR TITLE
Refactor MCP GitHub importer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,6 +4890,7 @@ dependencies = [
  "shinkai_tools_primitives",
  "shinkai_tools_runner",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-tungstenite 0.15.0",
  "tokio-util",

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -92,6 +92,7 @@ toml = "0.8.22"
 ngrok = { version = "0.15.0", features = ["hyper"], optional = true }
 url = "2.5.0"
 serde_yaml = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mockito = "1.0.2"

--- a/shinkai-bin/shinkai-node/src/network/mcp_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/mcp_manager.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::utils::github_mcp::{
-    extract_env_vars_from_smithery_yaml, extract_mcp_env_vars_from_readme,
-    fetch_github_file, parse_github_url, GitHubRepo,
+    extract_command_from_smithery_yaml, extract_env_vars_from_smithery_yaml,
+    extract_mcp_env_vars_from_readme, fetch_github_file, parse_github_url,
+    GitHubRepo, GitHubMcpError,
 };
 use reqwest::Client;
 use rmcp::model::Tool;
@@ -106,24 +107,24 @@ async fn process_python_mcp_project(
     pyproject_toml_content: String,
     _repo_info: &GitHubRepo,
     env_vars: HashSet<String>,
-) -> Result<AddMCPServerRequest, String> {
+) -> Result<AddMCPServerRequest, GitHubMcpError> {
     // Parse pyproject.toml
     let pyproject_toml: Table = pyproject_toml_content
         .parse::<Table>()
-        .map_err(|e| format!("Failed to parse pyproject.toml: {}", e))?;
+        .map_err(GitHubMcpError::TomlError)?;
 
     // Extract package name
     let project = pyproject_toml
         .get("project")
-        .ok_or_else(|| "Missing 'project' section in pyproject.toml".to_string())?
+        .ok_or_else(|| GitHubMcpError::MissingField("project".to_string()))?
         .as_table()
-        .ok_or_else(|| "Invalid 'project' section in pyproject.toml".to_string())?;
+        .ok_or_else(|| GitHubMcpError::Other("Invalid 'project' section in pyproject.toml".to_string()))?;
 
     let package_name = project
         .get("name")
-        .ok_or_else(|| "Missing 'name' field in pyproject.toml".to_string())?
+        .ok_or_else(|| GitHubMcpError::MissingField("name".to_string()))?
         .as_str()
-        .ok_or_else(|| "Invalid 'name' field in pyproject.toml".to_string())?
+        .ok_or_else(|| GitHubMcpError::Other("Invalid 'name' field in pyproject.toml".to_string()))?
         .to_string();
 
     // Check for project.scripts section to determine entry point
@@ -172,16 +173,16 @@ async fn process_nodejs_mcp_project(
     package_json_content: String,
     _repo_info: &GitHubRepo,
     env_vars: HashSet<String>,
-) -> Result<AddMCPServerRequest, String> {
+) -> Result<AddMCPServerRequest, GitHubMcpError> {
     // Parse package.json
     let package_json: Value =
-        serde_json::from_str(&package_json_content).map_err(|e| format!("Failed to parse package.json: {}", e))?;
+        serde_json::from_str(&package_json_content).map_err(GitHubMcpError::JsonError)?;
 
     // Extract package name
     let package_name = package_json
         .get("name")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| "Missing 'name' field in package.json".to_string())?
+        .ok_or_else(|| GitHubMcpError::MissingField("name".to_string()))?
         .to_string();
 
     // Create server name from package name
@@ -209,20 +210,22 @@ async fn process_nodejs_mcp_project(
     Ok(request)
 }
 
-pub async fn import_mcp_server_from_github_url(github_url: String) -> Result<AddMCPServerRequest, String> {
+pub async fn import_mcp_server_from_github_url(
+    github_url: String,
+) -> Result<AddMCPServerRequest, GitHubMcpError> {
     let repo_info = parse_github_url(&github_url)?;
 
-    let client = Client::builder()
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+    let client = Client::builder().build().map_err(GitHubMcpError::RequestError)?;
 
     // Try to fetch smithery.yaml first for environment variables
     let mut env_vars = HashSet::new();
     let smithery_result =
         fetch_github_file(&client, &repo_info.owner, &repo_info.repo, "smithery.yaml").await;
 
+    let mut command_override = None;
     if let Ok(smithery_content) = smithery_result {
         env_vars = extract_env_vars_from_smithery_yaml(&smithery_content);
+        command_override = extract_command_from_smithery_yaml(&smithery_content);
     } else {
         // Fallback to README.md regex extraction
         let readme_result =
@@ -236,24 +239,33 @@ pub async fn import_mcp_server_from_github_url(github_url: String) -> Result<Add
     }
 
     // Try to fetch package.json first (Node.js project)
-    let package_json_result = fetch_github_file(&client, &repo_info.owner, &repo_info.repo, "package.json").await;
+    let package_json_result =
+        fetch_github_file(&client, &repo_info.owner, &repo_info.repo, "package.json").await;
 
     if let Ok(package_json_content) = package_json_result {
-        return process_nodejs_mcp_project(package_json_content, &repo_info, env_vars).await;
+        let mut request = process_nodejs_mcp_project(package_json_content, &repo_info, env_vars).await?;
+        if let Some(cmd) = command_override {
+            request.command = Some(cmd);
+        }
+        return Ok(request);
     }
 
     // If package.json not found, try pyproject.toml (Python project)
     let pyproject_toml_result = fetch_github_file(&client, &repo_info.owner, &repo_info.repo, "pyproject.toml").await;
 
     if let Ok(pyproject_toml_content) = pyproject_toml_result {
-        return process_python_mcp_project(pyproject_toml_content, &repo_info, env_vars).await;
+        let mut request = process_python_mcp_project(pyproject_toml_content, &repo_info, env_vars).await?;
+        if let Some(cmd) = command_override {
+            request.command = Some(cmd);
+        }
+        return Ok(request);
     }
 
     // If neither found, return error
-    Err(format!(
+    Err(GitHubMcpError::Other(format!(
         "Could not find package.json or pyproject.toml in repository {}/{}",
         repo_info.owner, repo_info.repo
-    ))
+    )))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- use `thiserror` for a new `GitHubMcpError` error type
- update GitHub utilities to return typed errors
- parse command information from `smithery.yaml`
- allow MCP import logic to override the command using `smithery.yaml`
- add `thiserror` to shinkai-node dependencies

## Testing
- `cargo test -p shinkai_node --no-run` *(fails: failed to download swagger-ui during build)*

------
https://chatgpt.com/codex/tasks/task_e_683cb12ddf2083219cc08d68f9fd5d09