### PR TITLE
Refactor MCP GitHub importer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,6 +4890,7 @@ dependencies = [
  "shinkai_tools_primitives",
  "shinkai_tools_runner",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-tungstenite 0.15.0",
  "tokio-util",

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -92,6 +92,7 @@ toml = "0.8.22"
 ngrok = { version = "0.15.0", features = ["hyper"], optional = true }
 url = "2.5.0"
 serde_yaml = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mockito = "1.0.2"

--- a/shinkai-bin/shinkai-node/src/network/mcp_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/mcp_manager.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::utils::github_mcp::{
     extract_env_vars_from_smithery_yaml, extract_mcp_env_vars_from_readme,
-    fetch_github_file, parse_github_url, GitHubRepo,
+    fetch_github_file, parse_github_url, GitHubRepo, GitHubMcpError,
 };
 use reqwest::Client;
 use rmcp::model::Tool;
@@ -106,24 +106,24 @@ async fn process_python_mcp_project(
     pyproject_toml_content: String,
     _repo_info: &GitHubRepo,
     env_vars: HashSet<String>,
-) -> Result<AddMCPServerRequest, String> {
+) -> Result<AddMCPServerRequest, GitHubMcpError> {
     // Parse pyproject.toml
     let pyproject_toml: Table = pyproject_toml_content
         .parse::<Table>()
-        .map_err(|e| format!("Failed to parse pyproject.toml: {}", e))?;
+        .map_err(GitHubMcpError::TomlError)?;
 
     // Extract package name
     let project = pyproject_toml
         .get("project")
-        .ok_or_else(|| "Missing 'project' section in pyproject.toml".to_string())?
+        .ok_or_else(|| GitHubMcpError::MissingField("project".to_string()))?
         .as_table()
-        .ok_or_else(|| "Invalid 'project' section in pyproject.toml".to_string())?;
+        .ok_or_else(|| GitHubMcpError::Other("Invalid 'project' section in pyproject.toml".to_string()))?;
 
     let package_name = project
         .get("name")
-        .ok_or_else(|| "Missing 'name' field in pyproject.toml".to_string())?
+        .ok_or_else(|| GitHubMcpError::MissingField("name".to_string()))?
         .as_str()
-        .ok_or_else(|| "Invalid 'name' field in pyproject.toml".to_string())?
+        .ok_or_else(|| GitHubMcpError::Other("Invalid 'name' field in pyproject.toml".to_string()))?
         .to_string();
 
     // Check for project.scripts section to determine entry point
@@ -172,16 +172,16 @@ async fn process_nodejs_mcp_project(
     package_json_content: String,
     _repo_info: &GitHubRepo,
     env_vars: HashSet<String>,
-) -> Result<AddMCPServerRequest, String> {
+) -> Result<AddMCPServerRequest, GitHubMcpError> {
     // Parse package.json
     let package_json: Value =
-        serde_json::from_str(&package_json_content).map_err(|e| format!("Failed to parse package.json: {}", e))?;
+        serde_json::from_str(&package_json_content).map_err(GitHubMcpError::JsonError)?;
 
     // Extract package name
     let package_name = package_json
         .get("name")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| "Missing 'name' field in package.json".to_string())?
+        .ok_or_else(|| GitHubMcpError::MissingField("name".to_string()))?
         .to_string();
 
     // Create server name from package name
@@ -209,12 +209,12 @@ async fn process_nodejs_mcp_project(
     Ok(request)
 }
 
-pub async fn import_mcp_server_from_github_url(github_url: String) -> Result<AddMCPServerRequest, String> {
+pub async fn import_mcp_server_from_github_url(
+    github_url: String,
+) -> Result<AddMCPServerRequest, GitHubMcpError> {
     let repo_info = parse_github_url(&github_url)?;
 
-    let client = Client::builder()
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+    let client = Client::builder().build().map_err(GitHubMcpError::RequestError)?;
 
     // Try to fetch smithery.yaml first for environment variables
     let mut env_vars = HashSet::new();
@@ -236,7 +236,8 @@ pub async fn import_mcp_server_from_github_url(github_url: String) -> Result<Add
     }
 
     // Try to fetch package.json first (Node.js project)
-    let package_json_result = fetch_github_file(&client, &repo_info.owner, &repo_info.repo, "package.json").await;
+    let package_json_result =
+        fetch_github_file(&client, &repo_info.owner, &repo_info.repo, "package.json").await;
 
     if let Ok(package_json_content) = package_json_result {
         return process_nodejs_mcp_project(package_json_content, &repo_info, env_vars).await;
@@ -250,10 +251,10 @@ pub async fn import_mcp_server_from_github_url(github_url: String) -> Result<Add
     }
 
     // If neither found, return error
-    Err(format!(
+    Err(GitHubMcpError::Other(format!(
         "Could not find package.json or pyproject.toml in repository {}/{}",
         repo_info.owner, repo_info.repo
-    ))
+    )))
 }
 
 #[cfg(test)]

--- a/shinkai-bin/shinkai-node/src/utils/github_mcp.rs
+++ b/shinkai-bin/shinkai-node/src/utils/github_mcp.rs
@@ -1,8 +1,27 @@
 use log::info;
 use regex::Regex;
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use std::collections::HashSet;
 use serde_yaml::Value as YamlValue;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GitHubMcpError {
+    #[error("Invalid GitHub URL: {0}")]
+    InvalidGitHubUrl(String),
+    #[error("HTTP request error: {0}")]
+    RequestError(#[from] reqwest::Error),
+    #[error("Failed to fetch file {path}: HTTP {status}")]
+    HttpStatusError { path: String, status: StatusCode },
+    #[error("TOML parse error: {0}")]
+    TomlError(#[from] toml::de::Error),
+    #[error("JSON parse error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("Missing field: {0}")]
+    MissingField(String),
+    #[error("{0}")]
+    Other(String),
+}
 
 /// GitHub repository information
 pub struct GitHubRepo {
@@ -12,7 +31,7 @@ pub struct GitHubRepo {
 }
 
 /// Parse a GitHub URL to extract owner and repository name
-pub fn parse_github_url(url: &str) -> Result<GitHubRepo, String> {
+pub fn parse_github_url(url: &str) -> Result<GitHubRepo, GitHubMcpError> {
     // Handle different GitHub URL formats
     let url = url.trim_end_matches('/');
 
@@ -28,7 +47,7 @@ pub fn parse_github_url(url: &str) -> Result<GitHubRepo, String> {
         }
     }
 
-    Err(format!("Invalid GitHub URL: {}", url))
+    Err(GitHubMcpError::InvalidGitHubUrl(url.to_string()))
 }
 
 /// Fetch a file from a GitHub repository
@@ -37,7 +56,7 @@ pub async fn fetch_github_file(
     owner: &str,
     repo: &str,
     path: &str,
-) -> Result<String, String> {
+) -> Result<String, GitHubMcpError> {
     let url = format!(
         "https://raw.githubusercontent.com/{}/{}/main/{}",
         owner, repo, path
@@ -45,40 +64,35 @@ pub async fn fetch_github_file(
 
     info!("Fetching file from GitHub: {}", url);
 
-    match client.get(&url).send().await {
-        Ok(response) => {
-            if response.status().is_success() {
-                match response.text().await {
-                    Ok(content) => Ok(content),
-                    Err(e) => Err(format!("Failed to read response content: {}", e)),
-                }
-            } else {
-                // Try with master branch if main fails
-                let master_url = format!(
-                    "https://raw.githubusercontent.com/{}/{}/master/{}",
-                    owner, repo, path
-                );
-
-                match client.get(&master_url).send().await {
-                    Ok(master_response) => {
-                        if master_response.status().is_success() {
-                            match master_response.text().await {
-                                Ok(content) => Ok(content),
-                                Err(e) => Err(format!("Failed to read response content: {}", e)),
-                            }
-                        } else {
-                            Err(format!(
-                                "Failed to fetch file: HTTP {}",
-                                master_response.status()
-                            ))
-                        }
-                    }
-                    Err(e) => Err(format!("Failed to fetch file: {}", e)),
-                }
-            }
-        }
-        Err(e) => Err(format!("Failed to fetch file: {}", e)),
+    let response = client.get(&url).send().await.map_err(GitHubMcpError::RequestError)?;
+    if response.status().is_success() {
+        return response
+            .text()
+            .await
+            .map_err(GitHubMcpError::RequestError);
     }
+
+    // Try with master branch if main fails
+    let master_url = format!(
+        "https://raw.githubusercontent.com/{}/{}/master/{}",
+        owner, repo, path
+    );
+    let master_response = client
+        .get(&master_url)
+        .send()
+        .await
+        .map_err(GitHubMcpError::RequestError)?;
+    if master_response.status().is_success() {
+        return master_response
+            .text()
+            .await
+            .map_err(GitHubMcpError::RequestError);
+    }
+
+    Err(GitHubMcpError::HttpStatusError {
+        path: master_url,
+        status: master_response.status(),
+    })
 }
 
 /// Extract environment variables from README.md content


### PR DESCRIPTION
## Summary
- use `thiserror` for a new `GitHubMcpError` error type
- update GitHub utilities to return typed errors
- cleanup MCP import logic and remove command override

## Testing
- `cargo test -p shinkai_node --no-run` *(fails: failed to download swagger-ui during build)*

------
https://chatgpt.com/codex/tasks/task_e_683cb12ddf2083219cc08d68f9fd5d09