### PR TITLE
Fix SSE tests and manage MCP server processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serial_test",
  "strip-ansi-escapes",
  "tokio",
  "tokio-test",

--- a/shinkai-libs/shinkai-mcp/Cargo.toml
+++ b/shinkai-libs/shinkai-mcp/Cargo.toml
@@ -27,3 +27,4 @@ strip-ansi-escapes = { workspace = true }
 [dev-dependencies]
 tokio-test = "0.4"
 mockall = "0.11"
+serial_test = "0.5"


### PR DESCRIPTION
## Summary
- allocate unique ports for SSE tests
- add `TestMCPServer` helper to cleanly spawn and kill MCP server
- serialize MCP test execution with `serial_test`
- depend on `serial_test` for MCP crate

## Testing
- `IS_TESTING=1 SKIP_IMPORT_FROM_DIRECTORY=true cargo test -- --test-threads=1` *(fails: curl download file exited with error status)*

------
https://chatgpt.com/codex/tasks/task_e_683cc4b4d9ac83218f7b542507d17cd6