### PR TITLE
Add optional swagger feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ The result will be placed in the folder `docs/openapi`.
 http://{NODE_IP}:{NODE_API_PORT}/v2/swagger-ui/
 ```
 
+The Swagger UI assets are not built by default to avoid network downloads during
+tests. If you want to include them, compile with the `swagger-ui` feature:
+
+```
+cargo build --features shinkai_node/swagger-ui
+```
+
 ## Tests
 
 Note: You must run these tests from the root directory of this repo.

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -16,6 +16,8 @@ default = []
 console = ["console-subscriber"]
 # Enable ngrok support when the `ngrok` feature is selected
 ngrok = ["dep:ngrok"]
+# Enable swagger-ui when this feature is selected
+swagger-ui = ["shinkai_http_api/swagger-ui"]
 # static-pdf-parser = ["shinkai_vector_resources/static-pdf-parser"]
 
 [lib]

--- a/shinkai-libs/shinkai-http-api/Cargo.toml
+++ b/shinkai-libs/shinkai-http-api/Cargo.toml
@@ -6,7 +6,7 @@ authors = { workspace = true }
 
 [dependencies]
 utoipa = { workspace = true }
-utoipa-swagger-ui = "7.1.0"
+utoipa-swagger-ui = { version = "7.1.0", optional = true, features = ["vendored"] }
 chrono = { workspace = true }
 bytes = "1.10.1"
 async-trait = { workspace = true }
@@ -38,3 +38,7 @@ tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 [dependencies.serde]
 workspace = true
 features = ["derive"]
+
+[features]
+default = []
+swagger-ui = ["utoipa-swagger-ui"]

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_router.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_router.rs
@@ -7,6 +7,7 @@ use super::api_v2_handlers_mcp_servers::mcp_server_routes;
 use super::api_v2_handlers_ngrok::ngrok_routes;
 use super::api_v2_handlers_oauth::oauth_routes;
 use super::api_v2_handlers_prompts::prompt_routes;
+#[cfg(feature = "swagger-ui")]
 use super::api_v2_handlers_swagger_ui::swagger_ui_routes;
 use super::api_v2_handlers_tools::tool_routes;
 use super::api_v2_handlers_vecfs::vecfs_routes;
@@ -28,6 +29,7 @@ pub fn v2_routes(
     let ext_agent_offers = ext_agent_offers_routes(node_commands_sender.clone());
     let wallet_routes = wallet_routes(node_commands_sender.clone());
     let custom_prompt = prompt_routes(node_commands_sender.clone());
+    #[cfg(feature = "swagger-ui")]
     let swagger_ui_routes = swagger_ui_routes();
     let tool_routes = tool_routes(node_commands_sender.clone());
     let cron_routes = cron_routes(node_commands_sender.clone(), node_name.clone());
@@ -35,7 +37,8 @@ pub fn v2_routes(
     let mcp_server_routes = mcp_server_routes(node_commands_sender.clone());
     let ngrok_routes = ngrok_routes(node_commands_sender.clone());
 
-    general_routes
+    #[cfg(feature = "swagger-ui")]
+    return general_routes
         .or(vecfs_routes)
         .or(job_routes)
         .or(ext_agent_offers)
@@ -46,7 +49,20 @@ pub fn v2_routes(
         .or(cron_routes)
         .or(oauth_routes)
         .or(mcp_server_routes)
-        .or(ngrok_routes)
+        .or(ngrok_routes);
+
+    #[cfg(not(feature = "swagger-ui"))]
+    return general_routes
+        .or(vecfs_routes)
+        .or(job_routes)
+        .or(ext_agent_offers)
+        .or(wallet_routes)
+        .or(custom_prompt)
+        .or(tool_routes)
+        .or(cron_routes)
+        .or(oauth_routes)
+        .or(mcp_server_routes)
+        .or(ngrok_routes);
 }
 
 pub fn with_sender(

--- a/shinkai-libs/shinkai-http-api/src/api_v2/mod.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/mod.rs
@@ -6,6 +6,7 @@ pub mod api_v2_handlers_mcp_servers;
 pub mod api_v2_handlers_my_agent_offers;
 pub mod api_v2_handlers_oauth;
 pub mod api_v2_handlers_prompts;
+#[cfg(feature = "swagger-ui")]
 pub mod api_v2_handlers_swagger_ui;
 pub mod api_v2_handlers_tools;
 pub mod api_v2_handlers_vecfs;


### PR DESCRIPTION
## Summary
- add `swagger-ui` feature to shinkai-http-api and shinkai-node crates
- gate swagger modules behind feature flags
- document how to enable swagger UI in README

## Testing
- `cargo check -p shinkai_http_api --quiet` *(fails: failed to download utoipa-swagger-ui-vendored)*

------
https://chatgpt.com/codex/tasks/task_e_683cd41b6adc832190563e7bb944dfbf