### PR TITLE
Add rerun directives for asset dirs

### DIFF
--- a/shinkai-bin/shinkai-node/build.rs
+++ b/shinkai-bin/shinkai-node/build.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 
 fn main() {
+    // Ensure the build script only runs when asset directories change
+    println!("cargo:rerun-if-changed=shinkai-tools-runner-resources");
+    println!("cargo:rerun-if-changed=../../pre-install");
+
     shinkai_tools_runner::copy_assets::copy_assets(
         Some(PathBuf::from("./")),
         Some(PathBuf::from("../../target").join(std::env::var("PROFILE").unwrap())),


### PR DESCRIPTION
## Summary
- ensure build script only reruns when asset directories change

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `IS_TESTING=1 cargo test -- --test-threads=1` *(fails: curl download error)*

------
https://chatgpt.com/codex/tasks/task_e_683cd5774c208321a9281a715a21c2d3