### PR TITLE
Replace anyhow with thiserror in MCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,7 +4750,6 @@ dependencies = [
 name = "shinkai_mcp"
 version = "1.0.10"
 dependencies = [
- "anyhow",
  "async-trait",
  "futures",
  "home",
@@ -4762,6 +4761,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-test",
  "tracing",
@@ -4936,7 +4936,6 @@ dependencies = [
 name = "shinkai_tools_primitives"
 version = "1.0.10"
 dependencies = [
- "anyhow",
  "base64 0.22.1",
  "log",
  "once_cell",
@@ -6104,8 +6103,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip 1.1.4",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/shinkai-libs/shinkai-mcp/Cargo.toml
+++ b/shinkai-libs/shinkai-mcp/Cargo.toml
@@ -6,7 +6,7 @@ description = "Methods to interact with MCP servers"
 authors = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/shinkai-libs/shinkai-mcp/src/error.rs
+++ b/shinkai-libs/shinkai-mcp/src/error.rs
@@ -1,0 +1,70 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct McpError {
+    pub message: String,
+}
+
+impl From<Box<dyn std::error::Error + Send + Sync>> for McpError {
+    fn from(err: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<Box<dyn std::error::Error + Send>> for McpError {
+    fn from(err: Box<dyn std::error::Error + Send>) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<std::io::Error> for McpError {
+    fn from(err: std::io::Error) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<rmcp::Error> for McpError {
+    fn from(err: rmcp::Error) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<serde_json::Error> for McpError {
+    fn from(err: serde_json::Error) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<rmcp::transport::sse::SseTransportError> for McpError {
+    fn from(err: rmcp::transport::sse::SseTransportError) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<rmcp::service::ServiceError> for McpError {
+    fn from(err: rmcp::service::ServiceError) -> Self {
+        McpError {
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl From<String> for McpError {
+    fn from(err: String) -> Self {
+        McpError { message: err }
+    }
+}
+

--- a/shinkai-libs/shinkai-mcp/src/lib.rs
+++ b/shinkai-libs/shinkai-mcp/src/lib.rs
@@ -1,3 +1,4 @@
 mod command;
 mod utils;
 pub mod mcp_methods;
+pub mod error;

--- a/shinkai-libs/shinkai-tools-primitives/Cargo.toml
+++ b/shinkai-libs/shinkai-tools-primitives/Cargo.toml
@@ -11,7 +11,6 @@ regex = { workspace = true }
 shinkai_message_primitives = { workspace = true }
 # shinkai_vector_resources = { workspace = true }
 reqwest = { workspace = true, features = ["json", "tokio-native-tls"] }
-anyhow = { workspace = true }
 shinkai_tools_runner = { workspace = true, features = ["built-in-tools"] }
 serde = { workspace = true, features = ["derive"] }
 base64 = { workspace = true }

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/error.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/error.rs
@@ -95,9 +95,9 @@ impl From<SerdeError> for ToolError {
     }
 }
 
-impl From<anyhow::Error> for ToolError {
-    fn from(err: anyhow::Error) -> ToolError {
-        ToolError::ParseError(err.to_string())
+impl From<shinkai_mcp::error::McpError> for ToolError {
+    fn from(err: shinkai_mcp::error::McpError) -> ToolError {
+        ToolError::ParseError(err.message)
     }
 }
 

--- a/shinkai-libs/shinkai-tools-primitives/src/tools/mcp_server_tool.rs
+++ b/shinkai-libs/shinkai-tools-primitives/src/tools/mcp_server_tool.rs
@@ -118,7 +118,7 @@ impl MCPServerTool {
         tool: String,
         env: HashMap<String, String>,
         parameters: serde_json::Map<String, serde_json::Value>,
-    ) -> anyhow::Result<CallToolResult> {
+    ) -> Result<CallToolResult, shinkai_mcp::error::McpError> {
         match mcp_server.r#type {
             MCPServerType::Command => {
                 run_tool_via_command(mcp_server.command.unwrap_or_default(), tool, env, parameters).await


### PR DESCRIPTION
## Summary
- introduce `McpError` to replace `anyhow` usage
- update MCP methods to return `McpError`
- adjust tool primitives to work with new error type
- drop `anyhow` from relevant Cargo manifests

## Testing
- `cargo test` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_683cdcf3622483219cea7f5327df257d