### PR TITLE
Improve build speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ dashmap = "5.5.3"
 clap = "3.0.0-beta.5"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.25"
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { version = "0.32.1" }
 os_path = "0.8.0"
 utoipa = "4.2.3"
 warp = "0.3.7"
@@ -76,3 +76,4 @@ home = "0.5"
 strip-ansi-escapes = "0.2"
 tracing = "0.1.40"
 serde_yaml = "0.9.34+deprecated"
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ if you want to restart the node, you can delete the folder `storage` and run the
 cargo build
 ```
 Note: You must run this command from the root directory of this repo and make sure that you have set the required ENV variables.
+By default the build uses your system SQLite library. If you need the bundled
+version instead, build with the `bundled-sqlite` feature:
+
+```sh
+cargo build -p shinkai_node --features bundled-sqlite
+```
+
+### Speeding up Builds
+
+To cache compiler outputs you can enable [`sccache`](https://github.com/mozilla/sccache):
+
+```sh
+export RUSTC_WRAPPER=$(which sccache)
+```
+
+You can also reuse a shared target directory by setting `CARGO_TARGET_DIR` to a location outside the repository. Both options help reduce rebuild times, especially across clean checkouts.
 
 ## OpenAPI
 

--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -16,6 +16,8 @@ default = []
 console = ["console-subscriber"]
 # Enable ngrok support when the `ngrok` feature is selected
 ngrok = ["dep:ngrok"]
+# Enable bundled SQLite builds when necessary
+bundled-sqlite = ["shinkai_sqlite/bundled-sqlite"]
 # static-pdf-parser = ["shinkai_vector_resources/static-pdf-parser"]
 
 [lib]

--- a/shinkai-bin/shinkai-node/build.rs
+++ b/shinkai-bin/shinkai-node/build.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
 fn main() {
+    // Avoid running this build script on every build by watching the assets
+    // directory for changes.
+    println!("cargo:rerun-if-changed=shinkai-tools-runner-resources");
     shinkai_tools_runner::copy_assets::copy_assets(
         Some(PathBuf::from("./")),
         Some(PathBuf::from("../../target").join(std::env::var("PROFILE").unwrap())),

--- a/shinkai-libs/shinkai-sqlite/Cargo.toml
+++ b/shinkai-libs/shinkai-sqlite/Cargo.toml
@@ -29,6 +29,9 @@ ed25519-dalek = { workspace = true }
 semver = "1.0"
 log = { workspace = true }
 
+[features]
+bundled-sqlite = ["rusqlite/bundled"]
+
 [dependencies.serde]
 workspace = true
 features = ["derive"]


### PR DESCRIPTION
## Summary
- avoid running node build script every build
- document bundling instructions and build caching tips in README
- default to system SQLite and gate bundled compile behind feature
- allow selecting bundled SQLite from node crate

## Testing
- `cargo check -p shinkai_sqlite`
- `cargo test --workspace --no-run` *(fails: couldn't download swagger-ui due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683cd3a87614832195d5e0ed463cc0f9