### PR TITLE
Fix exported message formatting

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_jobs.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_jobs.rs
@@ -1748,7 +1748,17 @@ impl Node {
 
                 for messages in v2_chat_messages {
                     for message in messages {
-                        result_messages.push_str(&format!("{}\n\n", message.job_message.content));
+                        let role = if message
+                            .sender_subidentity
+                            .to_lowercase()
+                            .contains("/agent/")
+                        {
+                            "assistant"
+                        } else {
+                            "user"
+                        };
+
+                        result_messages.push_str(&format!("{}: {}\n\n", role, message.job_message.content));
 
                         for file in &message.job_message.fs_files_paths {
                             result_messages.push_str(&format!("Attached file: {}\n\n", file));


### PR DESCRIPTION
## Summary
- improve TXT export formatting to show sender role

## Testing
- `cargo test` *(fails: environment lacks network access after setup)*

------
https://chatgpt.com/codex/tasks/task_e_683d08103f5083218415922e896a0e6b