### PR TITLE
Handle EPIPE from MCP server processes

### DIFF
--- a/shinkai-libs/shinkai-mcp/node_exit_on_epipe.js
+++ b/shinkai-libs/shinkai-mcp/node_exit_on_epipe.js
@@ -1,0 +1,4 @@
+process.stdout.on('error', err => {
+  if (err.code === 'EPIPE') process.exit(0); // peer went away, exit silently
+  else throw err;
+});


### PR DESCRIPTION
## Summary
- avoid noisy EPIPE errors when MCP server closes stdout
- inject NODE_OPTIONS to require a small helper script
- add helper script that exits silently when stdout is closed

## Testing
- `cargo check -p shinkai_mcp`

------
https://chatgpt.com/codex/tasks/task_e_683d0a4dfd8c83218fbcedd8391fac0f