### PR TITLE
Add gzip compression to HTTP API

### DIFF
--- a/shinkai-libs/shinkai-http-api/Cargo.toml
+++ b/shinkai-libs/shinkai-http-api/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { workspace = true }
 bytes = "1.10.1"
 async-trait = { workspace = true }
 once_cell = "1.19.0"
-warp = { workspace = true, features = ["compression-gzip", "tls"] }
+warp = { workspace = true, features = ["compression", "compression-gzip", "tls"] }
 serde_json = { workspace = true }
 futures = { workspace = true }
 async-channel = { workspace = true }

--- a/shinkai-libs/shinkai-http-api/src/node_api_router.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_api_router.rs
@@ -19,6 +19,7 @@ use tokio_rustls::rustls::{self, ServerConfig};
 use tokio_rustls::TlsAcceptor;
 use utoipa::ToSchema;
 use warp::Filter;
+use warp::filters::compression;
 
 #[derive(serde::Serialize, ToSchema, Debug, Clone)]
 pub struct SendResponseBodyData {
@@ -165,7 +166,12 @@ pub async fn run_api(
     );
 
     // Combine all routes
-    let routes = v2_routes.or(mcp_routes).or(ws_routes).with(log).with(cors);
+    let routes = v2_routes
+        .or(mcp_routes)
+        .or(ws_routes)
+        .with(log)
+        .with(cors)
+        .with(compression::gzip());
 
     // Wrap the HTTP server in an async block that returns a Result
     let http_server = async {


### PR DESCRIPTION
## Summary
- enable warp `compression` feature to support gzip
- compress all HTTP API responses with gzip

## Testing
- `cargo check` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f63e5155c8321b4255e2476d4efc1