### PR TITLE
Add message tracing retrieval endpoint

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1639,6 +1639,12 @@ impl Node {
                     let _ = Node::v2_api_get_job_scope(db_clone, bearer, job_id, res).await;
                 });
             }
+            NodeCommand::V2ApiGetMessageTraces { bearer, message_id, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_get_message_traces(db_clone, bearer, message_id, res).await;
+                });
+            }
             // NodeCommand::V2ApiGetToolingLogs {
             //     bearer,
             //     message_id,

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -653,6 +653,11 @@ pub enum NodeCommand {
         message_id: String,
         res: Sender<Result<Value, APIError>>,
     },
+    V2ApiGetMessageTraces {
+        bearer: String,
+        message_id: String,
+        res: Sender<Result<Value, APIError>>,
+    },
     V2ApiExecuteTool {
         bearer: String,
         tool_router_key: String,


### PR DESCRIPTION
## Summary
- allow HTTP API consumers to retrieve message traces
- support retrieving traces via new node command
- wire up handler in node's command list

## Testing
- `cargo test --workspace --all-targets --quiet` *(fails: could not install rustfmt, build warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683f671a125c83218ebed19eae9a6dd0