### PR TITLE
Add tracing logs for LLM calls

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/generic_chain/generic_inference_chain.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/generic_chain/generic_inference_chain.rs
@@ -39,6 +39,7 @@ use std::time::Instant;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 use base64::Engine;
+use serde_json::json;
 
 #[derive(Clone)]
 pub struct GenericInferenceChain {
@@ -670,7 +671,7 @@ impl GenericInferenceChain {
             let response_res = JobManager::inference_with_llm_provider(
                 llm_provider.clone(),
                 filled_prompt.clone(),
-                inbox_name,
+                inbox_name.clone(),
                 ws_manager_trait.clone(),
                 job_config.cloned(),
                 llm_stopper.clone(),
@@ -737,7 +738,20 @@ impl GenericInferenceChain {
                     }
                     let shinkai_tool = shinkai_tool.unwrap();
 
-                    // TODO: add tracing to what tool is being called
+                    if let Some(ref msg_id) = message_hash_id {
+                        let trace_info = json!({
+                            "tool": shinkai_tool.tool_router_key().to_string_without_version(),
+                            "function": function_call.name
+                        });
+                        if let Err(e) = db.add_tracing(
+                            msg_id,
+                            inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                            "tool_call",
+                            &trace_info,
+                        ) {
+                            eprintln!("failed to add tool call trace: {:?}", e);
+                        }
+                    }
 
                     // Note: here we can add logic to handle the case that we have network tools
                     // TODO: if shinkai_tool is None we need to retry with the LLM (hallucination)
@@ -753,7 +767,21 @@ impl GenericInferenceChain {
                                 LLMProviderError::ToolRouterError(ref error_msg)
                                     if error_msg.contains("Invalid function arguments") =>
                                 {
-                                    // TODO: add tracing to what error is being returned
+
+                                    if let Some(ref msg_id) = message_hash_id {
+                                        let trace_info = json!({
+                                            "error": error_msg,
+                                            "function": function_call.name
+                                        });
+                                        if let Err(e) = db.add_tracing(
+                                            msg_id,
+                                            inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                                            "tool_error_invalid_arguments",
+                                            &trace_info,
+                                        ) {
+                                            eprintln!("failed to add tool error trace: {:?}", e);
+                                        }
+                                    }
 
                                     // For invalid arguments, we'll retry with the LLM by including the error
                                     // message in the next prompt to help it fix
@@ -800,7 +828,20 @@ impl GenericInferenceChain {
                                 LLMProviderError::ToolRouterError(ref error_msg)
                                     if error_msg.contains("MissingConfigError") =>
                                 {
-                                    // TODO: add tracing to what error is being returned
+                                    if let Some(ref msg_id) = message_hash_id {
+                                        let trace_info = json!({
+                                            "error": error_msg,
+                                            "function": function_call.name
+                                        });
+                                        if let Err(e) = db.add_tracing(
+                                            msg_id,
+                                            inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                                            "tool_error_missing_config",
+                                            &trace_info,
+                                        ) {
+                                            eprintln!("failed to add tool error trace: {:?}", e);
+                                        }
+                                    }
 
                                     // For missing config, we'll pass through the error directly
                                     // This will show up in the UI prompting the user to update their config
@@ -814,8 +855,20 @@ impl GenericInferenceChain {
                             }
                         }
                     };
-
-                    // TODO: add tracing to the tool response
+                    if let Some(ref msg_id) = message_hash_id {
+                        let trace_info = json!({
+                            "response": function_response.response,
+                            "function": function_call.name
+                        });
+                        if let Err(e) = db.add_tracing(
+                            msg_id,
+                            inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                            "tool_response",
+                            &trace_info,
+                        ) {
+                            eprintln!("failed to add tool response trace: {:?}", e);
+                        }
+                    }
 
                     let mut function_call_with_router_key = function_call.clone();
                     function_call_with_router_key.tool_router_key =

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/openai.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/openai.rs
@@ -140,7 +140,16 @@ impl LLMService for OpenAI {
                     format!("Call API Body: {:?}", payload_log).as_str(),
                 );
 
-                // TODO: add tracing of the payload
+                if let Some(ref msg_id) = tracing_message_id {
+                    if let Err(e) = db.add_tracing(
+                        msg_id,
+                        inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                        "llm_payload",
+                        &payload_log,
+                    ) {
+                        eprintln!("failed to add payload trace: {:?}", e);
+                    }
+                }
 
                 if is_stream {
                     handle_streaming_response(


### PR DESCRIPTION
## Summary
- trace OpenAI payloads via database
- trace tool calls and errors in GenericInferenceChain
- remove tracing crate dependency

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test --quiet` *(fails: command terminated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_683f6721d44883219905b9fba69a1ee5