### PR TITLE
Log LLM request payloads to DB

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/claude.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/claude.rs
@@ -122,6 +122,17 @@ impl LLMService for Claude {
                 truncate_image_url_in_payload(&mut payload_log);
                 eprintln!("Call API Body: {:?}", payload_log);
 
+                if let Some(ref msg_id) = tracing_message_id {
+                    if let Err(e) = db.add_tracing(
+                        msg_id,
+                        inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                        "llm_payload",
+                        &payload_log,
+                    ) {
+                        eprintln!("failed to add payload trace: {:?}", e);
+                    }
+                }
+
                 if is_stream {
                     handle_streaming_response(
                         client,

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/deepseek.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/deepseek.rs
@@ -111,6 +111,17 @@ impl LLMService for DeepSeek {
                     format!("Call API Body: {:?}", payload_log).as_str(),
                 );
 
+                if let Some(ref msg_id) = tracing_message_id {
+                    if let Err(e) = db.add_tracing(
+                        msg_id,
+                        inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                        "llm_payload",
+                        &payload_log,
+                    ) {
+                        eprintln!("failed to add payload trace: {:?}", e);
+                    }
+                }
+
                 if is_stream {
                     handle_streaming_response(
                         client,

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/exo.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/exo.rs
@@ -73,8 +73,8 @@ impl LLMService for Exo {
         ws_manager_trait: Option<Arc<Mutex<dyn WSUpdateHandler + Send>>>,
         _config: Option<JobConfig>,
         _llm_stopper: Arc<LLMStopper>,
-        _db: Arc<SqliteManager>,
-        _tracing_message_id: Option<String>,
+        db: Arc<SqliteManager>,
+        tracing_message_id: Option<String>,
     ) -> Result<LLMInferenceResponse, LLMProviderError> {
         let session_id = Uuid::new_v4().to_string();
         if let Some(base_url) = url {
@@ -120,6 +120,17 @@ impl LLMService for Exo {
                 ShinkaiLogLevel::Debug,
                 format!("Call API Body: {:?}", payload_log).as_str(),
             );
+
+            if let Some(ref msg_id) = tracing_message_id {
+                if let Err(e) = db.add_tracing(
+                    msg_id,
+                    inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                    "llm_payload",
+                    &payload_log,
+                ) {
+                    eprintln!("failed to add payload trace: {:?}", e);
+                }
+            }
 
             let res = client.post(url).json(&payload).send().await?;
 

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/groq.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/groq.rs
@@ -40,7 +40,7 @@ impl LLMService for Groq {
         ws_manager_trait: Option<Arc<Mutex<dyn WSUpdateHandler + Send>>>,
         config: Option<JobConfig>,
         llm_stopper: Arc<LLMStopper>,
-        _db: Arc<SqliteManager>,
+        db: Arc<SqliteManager>,
         tracing_message_id: Option<String>,
     ) -> Result<LLMInferenceResponse, LLMProviderError> {
         let session_id = Uuid::new_v4().to_string();
@@ -116,6 +116,17 @@ impl LLMService for Groq {
                     ShinkaiLogLevel::Debug,
                     format!("Call API Body: {:?}", payload_log).as_str(),
                 );
+
+                if let Some(ref msg_id) = tracing_message_id {
+                    if let Err(e) = db.add_tracing(
+                        msg_id,
+                        inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                        "llm_payload",
+                        &payload_log,
+                    ) {
+                        eprintln!("failed to add payload trace: {:?}", e);
+                    }
+                }
 
                 if is_stream {
                     handle_streaming_response(

--- a/shinkai-bin/shinkai-node/src/llm_provider/providers/ollama.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/providers/ollama.rs
@@ -62,7 +62,7 @@ impl LLMService for Ollama {
         ws_manager_trait: Option<Arc<Mutex<dyn WSUpdateHandler + Send>>>,
         config: Option<JobConfig>,
         llm_stopper: Arc<LLMStopper>,
-        _db: Arc<SqliteManager>,
+        db: Arc<SqliteManager>,
         tracing_message_id: Option<String>,
     ) -> Result<LLMInferenceResponse, LLMProviderError> {
         let session_id = Uuid::new_v4().to_string();
@@ -139,6 +139,17 @@ impl LLMService for Ollama {
                     format!("Failed to serialize messages_json: {:?}", e).as_str(),
                 ),
             };
+
+            if let Some(ref msg_id) = tracing_message_id {
+                if let Err(e) = db.add_tracing(
+                    msg_id,
+                    inbox_name.as_ref().map(|i| i.get_value()).as_deref(),
+                    "llm_payload",
+                    &payload_log,
+                ) {
+                    eprintln!("failed to add payload trace: {:?}", e);
+                }
+            }
 
             if is_stream {
                 handle_streaming_response(


### PR DESCRIPTION
## Summary
- record payloads sent to LLM providers into SQLite tracing
- update Claude, DeepSeek, Exo, Gemini, Groq, Ollama, OpenRouter, ShinkaiBackend and TogetherAI providers

## Testing
- `cargo test -p shinkai_node --lib --quiet` *(fails: test_axios_request)*

------
https://chatgpt.com/codex/tasks/task_e_683fc250aec88321a16eec2648a1dd68