### PR TITLE
Add network tool retrieval endpoint

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1238,6 +1238,12 @@ impl Node {
                     let _ = Node::v2_api_get_shinkai_tool_metadata(db_clone, bearer, tool_router_key, res).await;
                 });
             }
+            NodeCommand::V2ApiGetNetworkToolWithOffering { bearer, tool_key_name, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_get_network_tool_with_offering(db_clone, bearer, tool_key_name, res).await;
+                });
+            }
             NodeCommand::V2ApiSetShinkaiTool {
                 bearer,
                 tool_key,

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -1068,6 +1068,11 @@ pub enum NodeCommand {
         tool_router_key: String,
         res: Sender<Result<Value, APIError>>,
     },
+    V2ApiGetNetworkToolWithOffering {
+        bearer: String,
+        tool_key_name: String,
+        res: Sender<Result<Value, APIError>>,
+    },
     V2ApiSetEnableMCPServer {
         bearer: String,
         mcp_server_id: i64,


### PR DESCRIPTION
## Summary
- add `V2ApiGetNetworkToolWithOffering` command
- implement handler and routing for `/v2/get_network_tool_with_offering`
- expose new API in external agent offerings module

## Testing
- `cargo test -p shinkai_http_api --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6840a3e31e308321af08f4fc8a994f49