### PR TITLE
Add network tools endpoint

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1222,6 +1222,22 @@ impl Node {
                     .await;
                 });
             }
+            NodeCommand::V2ApiListAllNetworkShinkaiTools { bearer, category, res } => {
+                let db_clone = Arc::clone(&self.db);
+                let tool_router_clone = self.tool_router.clone();
+                let node_name_clone = self.node_name.clone();
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_list_all_network_shinkai_tools(
+                        db_clone,
+                        bearer,
+                        node_name_clone,
+                        category,
+                        tool_router_clone,
+                        res,
+                    )
+                    .await;
+                });
+            }
             NodeCommand::V2ApiListAllShinkaiToolsVersions { bearer, res } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {
@@ -1453,14 +1469,8 @@ impl Node {
                 let wallet_manager_clone = self.wallet_manager.clone();
                 let node_name = self.node_name.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_get_wallet_balance(
-                        db_clone,
-                        wallet_manager_clone,
-                        bearer,
-                        node_name,
-                        res,
-                    )
-                    .await;
+                    let _ =
+                        Node::v2_api_get_wallet_balance(db_clone, wallet_manager_clone, bearer, node_name, res).await;
                 });
             }
             NodeCommand::V2ApiGetStorageLocation { bearer, res } => {
@@ -2643,7 +2653,11 @@ impl Node {
                     let _ = Node::v2_api_docker_status(res).await;
                 });
             }
-            NodeCommand::V2ApiSetNgrokAuthToken { bearer, auth_token, res } => {
+            NodeCommand::V2ApiSetNgrokAuthToken {
+                bearer,
+                auth_token,
+                res,
+            } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {
                     let _ = Node::v2_api_set_ngrok_auth_token(db_clone, bearer, auth_token, res).await;
@@ -2659,7 +2673,8 @@ impl Node {
                 let db_clone = Arc::clone(&self.db);
                 let node_env = fetch_node_environment();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_set_ngrok_enabled(db_clone, bearer, enabled, node_env.api_listen_address, res).await;
+                    let _ = Node::v2_api_set_ngrok_enabled(db_clone, bearer, enabled, node_env.api_listen_address, res)
+                        .await;
                 });
             }
             NodeCommand::V2ApiGetNgrokStatus { bearer, res } => {

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_tools.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_tools.rs
@@ -1,32 +1,66 @@
 use crate::{
-    llm_provider::job_manager::JobManager, managers::{tool_router::ToolRouter, IdentityManager}, network::{
-        node_error::NodeError, node_shareable_logic::{download_zip_from_url, ZipFileContents}, zip_export_import::zip_export_import::{generate_tool_zip, import_dependencies_tools, import_tool}, Node
-    }, tools::{
-        tool_definitions::definition_generation::{generate_tool_definitions, get_all_tools}, tool_execution::execution_coordinator::{execute_code, execute_mcp_tool_cmd, execute_tool_cmd}, tool_generation::v2_create_and_send_job_message, tool_prompts::{generate_code_prompt, tool_metadata_implementation_prompt}
-    }, utils::environment::NodeEnvironment
+    llm_provider::job_manager::JobManager,
+    managers::{tool_router::ToolRouter, IdentityManager},
+    network::{
+        node_error::NodeError,
+        node_shareable_logic::{download_zip_from_url, ZipFileContents},
+        zip_export_import::zip_export_import::{generate_tool_zip, import_dependencies_tools, import_tool},
+        Node,
+    },
+    tools::{
+        tool_definitions::definition_generation::{generate_tool_definitions, get_all_tools},
+        tool_execution::execution_coordinator::{execute_code, execute_mcp_tool_cmd, execute_tool_cmd},
+        tool_generation::v2_create_and_send_job_message,
+        tool_prompts::{generate_code_prompt, tool_metadata_implementation_prompt},
+    },
+    utils::environment::NodeEnvironment,
 };
 use async_channel::Sender;
 use base64::Engine;
 use chrono::Utc;
 use ed25519_dalek::{ed25519::signature::SignerMut, SigningKey};
 use reqwest::StatusCode;
+use rusqlite::Error as RusqliteError;
 use serde_json::{json, Map, Value};
 use shinkai_embedding::embedding_generator::EmbeddingGenerator;
 use shinkai_http_api::node_api_router::{APIError, SendResponseBodyData};
 use shinkai_message_primitives::{
     schemas::{
-        inbox_name::InboxName, indexable_version::IndexableVersion, job::JobLike, job_config::JobConfig, shinkai_name::ShinkaiName, shinkai_name::ShinkaiSubidentityType, shinkai_tools::{CodeLanguage, DynamicToolType}, tool_router_key::ToolRouterKey
-    }, shinkai_message::shinkai_message_schemas::{CallbackAction, JobCreationInfo, JobMessage, MessageSchemaType}, shinkai_utils::{
-        job_scope::MinimalJobScope, shinkai_message_builder::ShinkaiMessageBuilder, signatures::clone_signature_secret_key
-    }
+        inbox_name::InboxName,
+        indexable_version::IndexableVersion,
+        job::JobLike,
+        job_config::JobConfig,
+        shinkai_name::ShinkaiName,
+        shinkai_name::ShinkaiSubidentityType,
+        shinkai_tools::{CodeLanguage, DynamicToolType},
+        tool_router_key::ToolRouterKey,
+    },
+    shinkai_message::shinkai_message_schemas::{CallbackAction, JobCreationInfo, JobMessage, MessageSchemaType},
+    shinkai_utils::{
+        job_scope::MinimalJobScope, shinkai_message_builder::ShinkaiMessageBuilder,
+        signatures::clone_signature_secret_key,
+    },
 };
 use shinkai_sqlite::{errors::SqliteManagerError, SqliteManager};
-use rusqlite::Error as RusqliteError;
 use shinkai_tools_primitives::tools::{
-    deno_tools::DenoTool, error::ToolError, parameters::Parameters, python_tools::PythonTool, shinkai_tool::ShinkaiToolHeader, shinkai_tool::{ShinkaiTool, ShinkaiToolWithAssets}, tool_config::{OAuth, ToolConfig}, tool_output_arg::ToolOutputArg, tool_playground::{ToolPlayground, ToolPlaygroundMetadata}, tool_types::{OperatingSystem, RunnerType, ToolResult}
+    deno_tools::DenoTool,
+    error::ToolError,
+    parameters::Parameters,
+    python_tools::PythonTool,
+    shinkai_tool::ShinkaiToolHeader,
+    shinkai_tool::{ShinkaiTool, ShinkaiToolWithAssets},
+    tool_config::{OAuth, ToolConfig},
+    tool_output_arg::ToolOutputArg,
+    tool_playground::{ToolPlayground, ToolPlaygroundMetadata},
+    tool_types::{OperatingSystem, RunnerType, ToolResult},
 };
 use std::{
-    collections::HashMap, env, io::Read, path::{absolute, PathBuf}, sync::Arc, time::Instant
+    collections::HashMap,
+    env,
+    io::Read,
+    path::{absolute, PathBuf},
+    sync::Arc,
+    time::Instant,
 };
 use tokio::fs;
 use tokio::{process::Command, sync::Mutex};
@@ -505,6 +539,126 @@ impl Node {
                     code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
                     error: "Internal Server Error".to_string(),
                     message: format!("Failed to list mcp tools: {}", err),
+                };
+                let _ = res.send(Err(api_error)).await;
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn v2_api_list_all_network_shinkai_tools(
+        db: Arc<SqliteManager>,
+        bearer: String,
+        node_name: ShinkaiName,
+        category: Option<String>,
+        tool_router: Option<Arc<ToolRouter>>,
+        res: Sender<Result<Value, APIError>>,
+    ) -> Result<(), NodeError> {
+        if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
+            return Ok(());
+        }
+
+        match db.get_all_tool_headers() {
+            Ok(tools) => {
+                use std::collections::HashMap;
+                let mut tool_groups: HashMap<String, Vec<ShinkaiToolHeader>> = HashMap::new();
+
+                for tool in tools {
+                    if tool.tool_type.to_lowercase() == "network" {
+                        let tool_router_key = tool.tool_router_key.clone();
+                        tool_groups.entry(tool_router_key).or_default().push(tool);
+                    }
+                }
+
+                let mut latest_tools = Vec::new();
+                for (_, mut group) in tool_groups {
+                    if group.len() == 1 {
+                        latest_tools.push(group.pop().unwrap());
+                    } else {
+                        group.sort_by(|a, b| {
+                            let a_version = IndexableVersion::from_string(&a.version.clone())
+                                .unwrap_or(IndexableVersion::from_number(0));
+                            let b_version = IndexableVersion::from_string(&b.version.clone())
+                                .unwrap_or(IndexableVersion::from_number(0));
+                            b_version.cmp(&a_version)
+                        });
+
+                        latest_tools.push(group.remove(0));
+                    }
+                }
+
+                let filtered_tools = if let Some(category) = category {
+                    match category.to_lowercase().as_str() {
+                        "downloaded" => {
+                            let default_tool_keys = if let Some(router) = &tool_router {
+                                Some(router.get_default_tool_router_keys_as_set().await)
+                            } else {
+                                None
+                            };
+
+                            let node_name_string = node_name.get_node_name_string();
+
+                            latest_tools
+                                .into_iter()
+                                .filter(|tool| {
+                                    let is_not_default = if let Some(default_keys) = &default_tool_keys {
+                                        !default_keys.contains(&tool.tool_router_key)
+                                    } else {
+                                        true
+                                    };
+
+                                    let is_not_localhost = !tool.author.starts_with("localhost.");
+
+                                    let is_not_node_name = tool.author != node_name_string;
+
+                                    let is_not_rust = !matches!(tool.tool_type.to_lowercase().as_str(), "rust");
+
+                                    is_not_default && is_not_localhost && is_not_node_name && is_not_rust
+                                })
+                                .collect()
+                        }
+                        "default" => {
+                            let default_tool_keys = if let Some(router) = &tool_router {
+                                Some(router.get_default_tool_router_keys_as_set().await)
+                            } else {
+                                None
+                            };
+
+                            if let Some(default_keys) = &default_tool_keys {
+                                latest_tools
+                                    .into_iter()
+                                    .filter(|tool| default_keys.contains(&tool.tool_router_key))
+                                    .collect()
+                            } else {
+                                latest_tools
+                            }
+                        }
+                        "system" => latest_tools
+                            .into_iter()
+                            .filter(|tool| matches!(tool.tool_type.to_lowercase().as_str(), "rust"))
+                            .collect(),
+                        "my_tools" => {
+                            let node_name_string = node_name.get_node_name_string();
+                            latest_tools
+                                .into_iter()
+                                .filter(|tool| tool.author.starts_with("localhost.") || tool.author == node_name_string)
+                                .collect()
+                        }
+                        _ => latest_tools,
+                    }
+                } else {
+                    latest_tools
+                };
+
+                let t = filtered_tools.iter().map(|tool| json!(tool)).collect();
+                let _ = res.send(Ok(t)).await;
+                Ok(())
+            }
+            Err(err) => {
+                let api_error = APIError {
+                    code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                    error: "Internal Server Error".to_string(),
+                    message: format!("Failed to list network tools: {}", err),
                 };
                 let _ = res.send(Err(api_error)).await;
                 Ok(())

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_tools.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_tools.rs
@@ -1,18 +1,29 @@
 use async_channel::Sender;
+use bytes::Buf;
+use futures::TryStreamExt;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use shinkai_message_primitives::{schemas::{shinkai_tools::{CodeLanguage, DynamicToolType}, tool_router_key::ToolRouterKey}, shinkai_message::shinkai_message_schemas::JobMessage};
-use shinkai_tools_primitives::tools::{shinkai_tool::ShinkaiToolWithAssets, tool_config::OAuth, tool_playground::ToolPlayground, tool_types::{OperatingSystem, RunnerType}};
-use utoipa::{OpenApi, ToSchema};
-use warp::Filter;
-use reqwest::StatusCode;
+use shinkai_message_primitives::{
+    schemas::{
+        shinkai_tools::{CodeLanguage, DynamicToolType},
+        tool_router_key::ToolRouterKey,
+    },
+    shinkai_message::shinkai_message_schemas::JobMessage,
+};
+use shinkai_tools_primitives::tools::{
+    shinkai_tool::ShinkaiToolWithAssets,
+    tool_config::OAuth,
+    tool_playground::ToolPlayground,
+    tool_types::{OperatingSystem, RunnerType},
+};
 use std::collections::HashMap;
-use futures::TryStreamExt;
+use utoipa::{OpenApi, ToSchema};
 use warp::multipart::FormData;
-use bytes::Buf;
+use warp::Filter;
 
-use crate::{node_api_router::APIError, node_commands::NodeCommand};
 use super::api_v2_router::{create_success_response, with_sender};
+use crate::{node_api_router::APIError, node_commands::NodeCommand};
 
 pub fn tool_routes(
     node_commands_sender: Sender<NodeCommand>,
@@ -23,6 +34,20 @@ pub fn tool_routes(
         .and(warp::header::<String>("authorization"))
         .and(warp::query::<HashMap<String, String>>())
         .and_then(list_all_shinkai_tools_handler);
+
+    let list_all_mcp_shinkai_tools_route = warp::path("list_all_mcp_shinkai_tools")
+        .and(warp::get())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::query::<HashMap<String, String>>())
+        .and_then(list_all_mcp_shinkai_tools_handler);
+
+    let list_all_network_shinkai_tools_route = warp::path("list_all_network_shinkai_tools")
+        .and(warp::get())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::query::<HashMap<String, String>>())
+        .and_then(list_all_network_shinkai_tools_handler);
 
     let set_shinkai_tool_route = warp::path("set_shinkai_tool")
         .and(warp::post())
@@ -64,7 +89,7 @@ pub fn tool_routes(
         .and(warp::header::<String>("authorization"))
         .and(warp::query::<HashMap<String, String>>())
         .and_then(search_shinkai_tool_handler);
-    
+
     let get_shinkai_tools_by_tool_set_route = warp::path("tools_from_toolset")
         .and(warp::get())
         .and(with_sender(node_commands_sender.clone()))
@@ -95,7 +120,7 @@ pub fn tool_routes(
         .and(warp::header::optional::<String>("x-shinkai-agent-id"))
         .and(warp::body::json())
         .and_then(tool_execution_handler);
-    
+
     let tool_definitions_route = warp::path("tool_definitions")
         .and(with_sender(node_commands_sender.clone()))
         .and(warp::header::<String>("authorization"))
@@ -343,6 +368,8 @@ pub fn tool_routes(
         .or(list_tool_asset_route)
         .or(delete_tool_asset_route)
         .or(remove_tool_route)
+        .or(list_all_mcp_shinkai_tools_route)
+        .or(list_all_network_shinkai_tools_route)
         .or(enable_all_tools_route)
         .or(disable_all_tools_route)
         .or(tool_store_proxy_route)
@@ -388,13 +415,11 @@ pub async fn tool_definitions_handler(
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
 
     // Get language from query params, default to Language::Typescript if not provided
-    let language = query_params
-        .get("language")
-        .and_then(|s| match s.as_str() {
-            "typescript" => Some(CodeLanguage::Typescript),
-            "python" => Some(CodeLanguage::Python),
-            _ => None,
-        });
+    let language = query_params.get("language").and_then(|s| match s.as_str() {
+        "typescript" => Some(CodeLanguage::Typescript),
+        "python" => Some(CodeLanguage::Python),
+        _ => None,
+    });
 
     if language.is_none() {
         return Err(warp::reject::custom(APIError {
@@ -410,12 +435,15 @@ pub async fn tool_definitions_handler(
         .unwrap_or_default();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiGenerateToolDefinitions {
             bearer,
             language: language.unwrap(),
-            tools: tools.iter().filter_map(|t| ToolRouterKey::from_string(t).ok ()).collect(),
+            tools: tools
+                .iter()
+                .filter_map(|t| ToolRouterKey::from_string(t).ok())
+                .collect(),
             res: res_sender,
         })
         .await
@@ -434,7 +462,6 @@ pub async fn tool_definitions_handler(
         )),
     }
 }
-
 
 #[derive(Deserialize, ToSchema, Debug)]
 pub struct ToolExecutionRequest {
@@ -463,26 +490,30 @@ pub async fn tool_execution_handler(
     app_id: String,
     agent_id: Option<String>,
     payload: ToolExecutionRequest,
-) -> Result<impl warp::Reply, warp::Rejection> {    
+) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
 
     // Convert parameters to a Map if it isn't already
     let parameters = match payload.parameters {
         Value::Object(map) => map,
-        _ => return Err(warp::reject::custom(APIError {
-            code: 400,
-            error: "Invalid Parameters".to_string(),
-            message: "Parameters must be an object".to_string(),
-        })),
+        _ => {
+            return Err(warp::reject::custom(APIError {
+                code: 400,
+                error: "Invalid Parameters".to_string(),
+                message: "Parameters must be an object".to_string(),
+            }))
+        }
     };
 
     let extra_config = match payload.extra_config {
         Value::Object(map) => map,
-        _ => return Err(warp::reject::custom(APIError {
-            code: 400,
-            error: "Invalid Extra Config".to_string(),
-            message: "Extra Config must be an object".to_string(),
-        })),
+        _ => {
+            return Err(warp::reject::custom(APIError {
+                code: 400,
+                error: "Invalid Extra Config".to_string(),
+                message: "Extra Config must be an object".to_string(),
+            }))
+        }
     };
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
@@ -556,7 +587,7 @@ pub async fn tool_implementation_handler(
     payload: ToolImplementationRequest,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiGenerateToolImplementation {
             bearer: authorization.strip_prefix("Bearer ").unwrap_or("").to_string(),
@@ -618,7 +649,7 @@ pub async fn tool_metadata_implementation_handler(
     payload: ToolMetadataImplementationRequest,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiGenerateToolMetadataImplementation {
             bearer: authorization.strip_prefix("Bearer ").unwrap_or("").to_string(),
@@ -643,7 +674,6 @@ pub async fn tool_metadata_implementation_handler(
         )),
     }
 }
-
 
 #[utoipa::path(
     get,
@@ -674,7 +704,7 @@ pub async fn search_shinkai_tool_handler(
             })
         })?
         .to_string();
-    
+
     // Get the optional agent_or_llm parameter
     let agent_or_llm = query_params.get("agent_or_llm").cloned();
 
@@ -721,10 +751,95 @@ pub async fn list_all_shinkai_tools_handler(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
     let category = query_params.get("category").cloned();
-    
+
     let (res_sender, res_receiver) = async_channel::bounded(1);
     sender
         .send(NodeCommand::V2ApiListAllShinkaiTools {
+            bearer,
+            category,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
+        }
+        Err(error) => Ok(warp::reply::with_status(
+            warp::reply::json(&error),
+            StatusCode::from_u16(error.code).unwrap(),
+        )),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v2/list_all_mcp_shinkai_tools",
+    params(
+        ("category" = Option<String>, Query, description = "Optional category filter for tools. Use 'download' to only list tools from external sources.")
+    ),
+    responses(
+        (status = 200, description = "Successfully listed all MCP-enabled Shinkai tools", body = Value),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError),
+    )
+)]
+pub async fn list_all_mcp_shinkai_tools_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+    query_params: HashMap<String, String>,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let category = query_params.get("category").cloned();
+
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiListAllMcpShinkaiTools {
+            category,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
+        }
+        Err(error) => Ok(warp::reply::with_status(
+            warp::reply::json(&error),
+            StatusCode::from_u16(error.code).unwrap(),
+        )),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v2/list_all_network_shinkai_tools",
+    params(
+        ("category" = Option<String>, Query, description = "Optional category filter for tools. Use 'download' to only list tools from external sources.")
+    ),
+    responses(
+        (status = 200, description = "Successfully listed all network Shinkai tools", body = Value),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError),
+    )
+)]
+pub async fn list_all_network_shinkai_tools_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+    query_params: HashMap<String, String>,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let category = query_params.get("category").cloned();
+
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiListAllNetworkShinkaiTools {
             bearer,
             category,
             res: res_sender,
@@ -920,7 +1035,7 @@ pub async fn set_playground_tool_handler(
     sender
         .send(NodeCommand::V2ApiSetPlaygroundTool {
             bearer,
-            payload, 
+            payload,
             tool_id: safe_folder_name(&tool_id),
             app_id: safe_folder_name(&app_id),
             original_tool_key_path,
@@ -1087,19 +1202,16 @@ pub async fn get_tool_implementation_prompt_handler(
     sender: Sender<NodeCommand>,
     authorization: String,
     query_params: HashMap<String, String>,
-
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
-    
-        // Get language from query params, default to Language::Typescript if not provided
-        let language = query_params
-        .get("language")
-        .and_then(|s| match s.as_str() {
-            "typescript" => Some(CodeLanguage::Typescript),
-            "python" => Some(CodeLanguage::Python),
-            _ => None,
-        });
-        
+
+    // Get language from query params, default to Language::Typescript if not provided
+    let language = query_params.get("language").and_then(|s| match s.as_str() {
+        "typescript" => Some(CodeLanguage::Typescript),
+        "python" => Some(CodeLanguage::Python),
+        _ => None,
+    });
+
     if language.is_none() {
         return Err(warp::reject::custom(APIError {
             code: 400,
@@ -1116,10 +1228,7 @@ pub async fn get_tool_implementation_prompt_handler(
         .filter_map(|t| ToolRouterKey::from_string(t).ok())
         .collect();
 
-    let code = query_params
-        .get("code")
-        .map_or("", |v| v)  
-        .to_string();
+    let code = query_params.get("code").map_or("", |v| v).to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
     sender
@@ -1191,20 +1300,24 @@ pub async fn code_execution_handler(
     // Convert parameters to a Map if it isn't already
     let parameters = match payload.parameters {
         Value::Object(map) => map,
-        _ => return Err(warp::reject::custom(APIError {
-            code: 400,
-            error: "Invalid Parameters".to_string(),
-            message: "Parameters must be an object".to_string(),
-        })),
+        _ => {
+            return Err(warp::reject::custom(APIError {
+                code: 400,
+                error: "Invalid Parameters".to_string(),
+                message: "Parameters must be an object".to_string(),
+            }))
+        }
     };
 
     let extra_config = match payload.extra_config {
         Value::Object(map) => map,
-        _ => return Err(warp::reject::custom(APIError {
-            code: 400,
-            error: "Invalid Extra Config".to_string(),
-            message: "Extra Config must be an object".to_string(),
-        })),
+        _ => {
+            return Err(warp::reject::custom(APIError {
+                code: 400,
+                error: "Invalid Extra Config".to_string(),
+                message: "Extra Config must be an object".to_string(),
+            }))
+        }
     };
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
@@ -1380,7 +1493,7 @@ pub async fn export_tool_handler(
         .to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiExportTool {
             bearer,
@@ -1404,11 +1517,11 @@ pub async fn export_tool_handler(
         Err(error) => Ok(warp::reply::with_header(
             warp::reply::with_status(
                 error.message.as_bytes().to_vec(),
-                StatusCode::from_u16(error.code).unwrap()
+                StatusCode::from_u16(error.code).unwrap(),
             ),
             "Content-Type",
             "text/plain",
-        ))
+        )),
     }
 }
 
@@ -1442,7 +1555,7 @@ pub async fn publish_tool_handler(
         .to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiPublishTool {
             bearer,
@@ -1490,7 +1603,7 @@ pub async fn import_tool_handler(
     let url = payload.url;
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiImportTool {
             bearer,
@@ -1538,7 +1651,7 @@ pub async fn import_tool_zip_handler(
             // Read file data with error handling
             let mut bytes = Vec::new();
             let mut stream = part.stream();
-            
+
             while let Ok(Some(chunk)) = stream.try_next().await {
                 if bytes.len() + chunk.chunk().len() > 50 * 1024 * 1024 {
                     return Ok(warp::reply::with_status(
@@ -1552,7 +1665,7 @@ pub async fn import_tool_zip_handler(
                 }
                 bytes.extend_from_slice(chunk.chunk());
             }
-            
+
             if bytes.is_empty() {
                 return Ok(warp::reply::with_status(
                     warp::reply::json(&APIError {
@@ -1563,7 +1676,7 @@ pub async fn import_tool_zip_handler(
                     StatusCode::BAD_REQUEST,
                 ));
             }
-            
+
             file_data = Some(bytes);
         }
     }
@@ -1584,26 +1697,27 @@ pub async fn import_tool_zip_handler(
     };
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     match sender
         .send(NodeCommand::V2ApiImportToolZip {
             bearer,
             file_data,
             res: res_sender,
         })
-        .await {
-            Ok(_) => (),
-            Err(_) => {
-                return Ok(warp::reply::with_status(
-                    warp::reply::json(&APIError {
-                        code: 500,
-                        error: "Internal server error".to_string(),
-                        message: "Failed to process the request".to_string(),
-                    }),
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                ))
-            }
-        };
+        .await
+    {
+        Ok(_) => (),
+        Err(_) => {
+            return Ok(warp::reply::with_status(
+                warp::reply::json(&APIError {
+                    code: 500,
+                    error: "Internal server error".to_string(),
+                    message: "Failed to process the request".to_string(),
+                }),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
+    };
 
     let result = match res_receiver.recv().await {
         Ok(result) => result,
@@ -1661,7 +1775,7 @@ pub async fn resolve_shinkai_file_protocol_handler(
         .to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiResolveShinkaiFileProtocol {
             bearer,
@@ -1685,11 +1799,11 @@ pub async fn resolve_shinkai_file_protocol_handler(
         Err(error) => Ok(warp::reply::with_header(
             warp::reply::with_status(
                 error.message.as_bytes().to_vec(),
-                StatusCode::from_u16(error.code).unwrap()
+                StatusCode::from_u16(error.code).unwrap(),
             ),
             "Content-Type",
             "text/plain",
-        ))
+        )),
     }
 }
 
@@ -1813,7 +1927,7 @@ pub async fn tool_asset_handler(
     }
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiUploadToolAsset {
             bearer,
@@ -1912,7 +2026,7 @@ pub async fn playground_file_handler(
     }
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiUploadPlaygroundFile {
             bearer,
@@ -1957,7 +2071,7 @@ pub async fn list_tool_asset_handler(
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiListToolAssets {
             bearer,
@@ -2015,7 +2129,7 @@ pub async fn delete_tool_asset_handler(
         .to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiDeleteToolAsset {
             bearer,
@@ -2144,24 +2258,27 @@ pub async fn duplicate_tool_handler(
         ));
     }
     sender
-        .send(NodeCommand::V2ApiDuplicateTool { bearer, tool_key_path, res: res_sender })
+        .send(NodeCommand::V2ApiDuplicateTool {
+            bearer,
+            tool_key_path,
+            res: res_sender,
+        })
         .await
         .map_err(|_| warp::reject::reject())?;
 
-        let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
 
-        match result {
-            Ok(response) => {
-                let response = create_success_response(response);
-                Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
-            }
-            Err(error) => Ok(warp::reply::with_status(
-                warp::reply::json(&error),
-                StatusCode::from_u16(error.code).unwrap(),
-            )),
+    match result {
+        Ok(response) => {
+            let response = create_success_response(response);
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
         }
+        Err(error) => Ok(warp::reply::with_status(
+            warp::reply::json(&error),
+            StatusCode::from_u16(error.code).unwrap(),
+        )),
     }
-
+}
 
 #[utoipa::path(
     get,
@@ -2183,7 +2300,7 @@ pub async fn tool_store_proxy_handler(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiStoreProxy {
             bearer,
@@ -2236,7 +2353,7 @@ pub async fn standalone_playground_handler(
     payload: StandAlonePlaygroundRequest,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
-    
+
     let (res_sender, res_receiver) = async_channel::bounded(1);
     sender
         .send(NodeCommand::V2ApiStandAlonePlayground {
@@ -2270,7 +2387,6 @@ pub async fn standalone_playground_handler(
         )),
     }
 }
-
 
 #[utoipa::path(
     get,
@@ -2331,7 +2447,7 @@ pub async fn set_tool_enabled_handler(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
     let (res_sender, res_receiver) = async_channel::bounded(1);
-    
+
     sender
         .send(NodeCommand::V2ApiSetToolEnabled {
             bearer,
@@ -2406,7 +2522,7 @@ pub async fn set_tool_mcp_enabled_handler(
 #[derive(Debug, Deserialize)]
 pub struct CopyToolAssetsRequest {
     pub is_first_playground: bool,
-    pub first_path: String,  // app_id for playground or tool_key_path for tool
+    pub first_path: String, // app_id for playground or tool_key_path for tool
     pub is_second_playground: bool,
     pub second_path: String, // app_id for playground or tool_key_path for tool
 }
@@ -2464,9 +2580,7 @@ pub async fn get_tools_from_toolset_handler(
     })?;
 
     match result {
-        Ok(tools) => {
-            Ok(warp::reply::with_status(warp::reply::json(&tools), StatusCode::OK))
-        }
+        Ok(tools) => Ok(warp::reply::with_status(warp::reply::json(&tools), StatusCode::OK)),
         Err(error) => {
             Ok(warp::reply::with_status(
                 warp::reply::json(&error),
@@ -2522,12 +2636,10 @@ pub async fn set_common_toolset_config_handler(
     match result {
         Ok(updated_tool_keys) => {
             let response = SetCommonToolSetConfigResponse { updated_tool_keys };
-            Ok(warp::reply::with_status(
-                warp::reply::json(&response),
-                StatusCode::OK,
-            ))
+            Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK))
         }
-        Err(e) => { // fallback
+        Err(e) => {
+            // fallback
             Ok(warp::reply::with_status(
                 warp::reply::json(&e),
                 StatusCode::from_u16(e.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR), // Fallback to 500 if code is invalid
@@ -2551,7 +2663,7 @@ pub async fn copy_tool_assets_handler(
     payload: CopyToolAssetsRequest,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
-    
+
     let (res_sender, res_receiver) = async_channel::bounded(1);
     sender
         .send(NodeCommand::V2ApiCopyToolAssets {
@@ -2579,7 +2691,6 @@ pub async fn copy_tool_assets_handler(
     }
 }
 
-
 #[derive(Deserialize, ToSchema, Debug)]
 pub struct ToolCheckRequest {
     code: String,
@@ -2601,7 +2712,7 @@ pub async fn tool_check_handler(
     sender: Sender<NodeCommand>,
     authorization: String,
     payload: ToolCheckRequest,
-) -> Result<impl warp::Reply, warp::Rejection> {    
+) -> Result<impl warp::Reply, warp::Rejection> {
     let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
 
     let (res_sender, res_receiver) = async_channel::bounded(1);
@@ -2638,6 +2749,8 @@ pub async fn tool_check_handler(
         tool_implementation_handler,
         tool_metadata_implementation_handler,
         list_all_shinkai_tools_handler,
+        list_all_mcp_shinkai_tools_handler,
+        list_all_network_shinkai_tools_handler,
         set_shinkai_tool_handler,
         get_shinkai_tool_handler,
         search_shinkai_tool_handler,
@@ -2672,7 +2785,7 @@ pub async fn tool_check_handler(
     ),
     components(
         schemas(
-            APIError, 
+            APIError,
             ToolExecutionRequest,
             SetToolEnabledRequest,
             SetToolMcpEnabledRequest,

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -11,11 +11,7 @@ use shinkai_message_primitives::{
         custom_prompt::CustomPrompt,
         identity::{Identity, StandardIdentity},
         job_config::JobConfig,
-        llm_providers::{
-            agent::Agent,
-            serialized_llm_provider::SerializedLLMProvider,
-            shinkai_backend::QuotaResponse,
-        },
+        llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider, shinkai_backend::QuotaResponse},
         mcp_server::MCPServer,
         shinkai_name::ShinkaiName,
         shinkai_tool_offering::{ShinkaiToolOffering, UsageTypeInquiry},
@@ -24,16 +20,27 @@ use shinkai_message_primitives::{
         tool_router_key::ToolRouterKey,
         wallet_complementary::{WalletRole, WalletSource},
         wallet_mixed::NetworkIdentifier,
-        x402_types::Network
-    }, shinkai_message::{
-        shinkai_message::ShinkaiMessage, shinkai_message_schemas::{
-            APIAddOllamaModels, APIChangeJobAgentRequest, APIVecFsCopyFolder, APIVecFsCopyItem, APIVecFsCreateFolder, APIVecFsDeleteFolder, APIVecFsDeleteItem, APIVecFsMoveFolder, APIVecFsMoveItem, APIVecFsRetrievePathSimplifiedJson, APIVecFsRetrieveSourceFile, APIVecFsSearchItems, ExportInboxMessagesFormat, IdentityPermissions, JobCreationInfo, JobMessage, RegistrationCodeType, V2ChatMessage
-        }
-    }, shinkai_utils::job_scope::MinimalJobScope
+        x402_types::Network,
+    },
+    shinkai_message::{
+        shinkai_message::ShinkaiMessage,
+        shinkai_message_schemas::{
+            APIAddOllamaModels, APIChangeJobAgentRequest, APIVecFsCopyFolder, APIVecFsCopyItem, APIVecFsCreateFolder,
+            APIVecFsDeleteFolder, APIVecFsDeleteItem, APIVecFsMoveFolder, APIVecFsMoveItem,
+            APIVecFsRetrievePathSimplifiedJson, APIVecFsRetrieveSourceFile, APIVecFsSearchItems,
+            ExportInboxMessagesFormat, IdentityPermissions, JobCreationInfo, JobMessage, RegistrationCodeType,
+            V2ChatMessage,
+        },
+    },
+    shinkai_utils::job_scope::MinimalJobScope,
 };
 
 use shinkai_tools_primitives::tools::{
-    mcp_server_tool::MCPServerTool, shinkai_tool::{ShinkaiTool, ShinkaiToolHeader, ShinkaiToolWithAssets}, tool_config::OAuth, tool_playground::ToolPlayground, tool_types::{OperatingSystem, RunnerType}
+    mcp_server_tool::MCPServerTool,
+    shinkai_tool::{ShinkaiTool, ShinkaiToolHeader, ShinkaiToolWithAssets},
+    tool_config::OAuth,
+    tool_playground::ToolPlayground,
+    tool_types::{OperatingSystem, RunnerType},
 };
 // use crate::{
 //     prompts::custom_prompt::CustomPrompt, tools::shinkai_tool::{ShinkaiTool, ShinkaiToolHeader}, wallet::{
@@ -43,11 +50,13 @@ use shinkai_tools_primitives::tools::{
 use x25519_dalek::PublicKey as EncryptionPublicKey;
 
 use crate::{
-    api_v2::api_v2_handlers_mcp_servers::{AddMCPServerRequest, DeleteMCPServerResponse, UpdateMCPServerRequest}, node_api_router::{APIUseRegistrationCodeSuccessResponse, SendResponseBody}
+    api_v2::api_v2_handlers_mcp_servers::{AddMCPServerRequest, DeleteMCPServerResponse, UpdateMCPServerRequest},
+    node_api_router::{APIUseRegistrationCodeSuccessResponse, SendResponseBody},
 };
 
 use super::{
-    api_v2::api_v2_handlers_general::InitialRegistrationRequest, node_api_router::{APIError, GetPublicKeysResponse, SendResponseBodyData}
+    api_v2::api_v2_handlers_general::InitialRegistrationRequest,
+    node_api_router::{APIError, GetPublicKeysResponse, SendResponseBodyData},
 };
 
 pub enum NodeCommand {
@@ -383,6 +392,11 @@ pub enum NodeCommand {
         res: Sender<Result<Value, APIError>>,
     },
     V2ApiListAllMcpShinkaiTools {
+        category: Option<String>,
+        res: Sender<Result<Value, APIError>>,
+    },
+    V2ApiListAllNetworkShinkaiTools {
+        bearer: String,
         category: Option<String>,
         res: Sender<Result<Value, APIError>>,
     },


### PR DESCRIPTION
## Summary
- add bearer token validation to network tools listing
- filter network tools using `tool_type` string
- include new command fields in API handlers and node command processing

## Testing
- `cargo test -p shinkai_http_api --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6840cd21fb688321ac32489d8b8ce641