### PR TITLE
Add Network tools listing endpoint

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1222,6 +1222,21 @@ impl Node {
                     .await;
                 });
             }
+            NodeCommand::V2ApiListAllNetworkShinkaiTools { bearer, res } => {
+                let db_clone = Arc::clone(&self.db);
+                let tool_router_clone = self.tool_router.clone();
+                let node_name_clone = self.node_name.clone();
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_list_all_network_shinkai_tools(
+                        db_clone,
+                        bearer,
+                        node_name_clone,
+                        tool_router_clone,
+                        res,
+                    )
+                    .await;
+                });
+            }
             NodeCommand::V2ApiListAllShinkaiToolsVersions { bearer, res } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {
@@ -1453,14 +1468,8 @@ impl Node {
                 let wallet_manager_clone = self.wallet_manager.clone();
                 let node_name = self.node_name.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_get_wallet_balance(
-                        db_clone,
-                        wallet_manager_clone,
-                        bearer,
-                        node_name,
-                        res,
-                    )
-                    .await;
+                    let _ =
+                        Node::v2_api_get_wallet_balance(db_clone, wallet_manager_clone, bearer, node_name, res).await;
                 });
             }
             NodeCommand::V2ApiGetStorageLocation { bearer, res } => {
@@ -2643,7 +2652,11 @@ impl Node {
                     let _ = Node::v2_api_docker_status(res).await;
                 });
             }
-            NodeCommand::V2ApiSetNgrokAuthToken { bearer, auth_token, res } => {
+            NodeCommand::V2ApiSetNgrokAuthToken {
+                bearer,
+                auth_token,
+                res,
+            } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {
                     let _ = Node::v2_api_set_ngrok_auth_token(db_clone, bearer, auth_token, res).await;
@@ -2659,7 +2672,8 @@ impl Node {
                 let db_clone = Arc::clone(&self.db);
                 let node_env = fetch_node_environment();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_set_ngrok_enabled(db_clone, bearer, enabled, node_env.api_listen_address, res).await;
+                    let _ = Node::v2_api_set_ngrok_enabled(db_clone, bearer, enabled, node_env.api_listen_address, res)
+                        .await;
                 });
             }
             NodeCommand::V2ApiGetNgrokStatus { bearer, res } => {

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -11,11 +11,7 @@ use shinkai_message_primitives::{
         custom_prompt::CustomPrompt,
         identity::{Identity, StandardIdentity},
         job_config::JobConfig,
-        llm_providers::{
-            agent::Agent,
-            serialized_llm_provider::SerializedLLMProvider,
-            shinkai_backend::QuotaResponse,
-        },
+        llm_providers::{agent::Agent, serialized_llm_provider::SerializedLLMProvider, shinkai_backend::QuotaResponse},
         mcp_server::MCPServer,
         shinkai_name::ShinkaiName,
         shinkai_tool_offering::{ShinkaiToolOffering, UsageTypeInquiry},
@@ -24,16 +20,27 @@ use shinkai_message_primitives::{
         tool_router_key::ToolRouterKey,
         wallet_complementary::{WalletRole, WalletSource},
         wallet_mixed::NetworkIdentifier,
-        x402_types::Network
-    }, shinkai_message::{
-        shinkai_message::ShinkaiMessage, shinkai_message_schemas::{
-            APIAddOllamaModels, APIChangeJobAgentRequest, APIVecFsCopyFolder, APIVecFsCopyItem, APIVecFsCreateFolder, APIVecFsDeleteFolder, APIVecFsDeleteItem, APIVecFsMoveFolder, APIVecFsMoveItem, APIVecFsRetrievePathSimplifiedJson, APIVecFsRetrieveSourceFile, APIVecFsSearchItems, ExportInboxMessagesFormat, IdentityPermissions, JobCreationInfo, JobMessage, RegistrationCodeType, V2ChatMessage
-        }
-    }, shinkai_utils::job_scope::MinimalJobScope
+        x402_types::Network,
+    },
+    shinkai_message::{
+        shinkai_message::ShinkaiMessage,
+        shinkai_message_schemas::{
+            APIAddOllamaModels, APIChangeJobAgentRequest, APIVecFsCopyFolder, APIVecFsCopyItem, APIVecFsCreateFolder,
+            APIVecFsDeleteFolder, APIVecFsDeleteItem, APIVecFsMoveFolder, APIVecFsMoveItem,
+            APIVecFsRetrievePathSimplifiedJson, APIVecFsRetrieveSourceFile, APIVecFsSearchItems,
+            ExportInboxMessagesFormat, IdentityPermissions, JobCreationInfo, JobMessage, RegistrationCodeType,
+            V2ChatMessage,
+        },
+    },
+    shinkai_utils::job_scope::MinimalJobScope,
 };
 
 use shinkai_tools_primitives::tools::{
-    mcp_server_tool::MCPServerTool, shinkai_tool::{ShinkaiTool, ShinkaiToolHeader, ShinkaiToolWithAssets}, tool_config::OAuth, tool_playground::ToolPlayground, tool_types::{OperatingSystem, RunnerType}
+    mcp_server_tool::MCPServerTool,
+    shinkai_tool::{ShinkaiTool, ShinkaiToolHeader, ShinkaiToolWithAssets},
+    tool_config::OAuth,
+    tool_playground::ToolPlayground,
+    tool_types::{OperatingSystem, RunnerType},
 };
 // use crate::{
 //     prompts::custom_prompt::CustomPrompt, tools::shinkai_tool::{ShinkaiTool, ShinkaiToolHeader}, wallet::{
@@ -43,11 +50,13 @@ use shinkai_tools_primitives::tools::{
 use x25519_dalek::PublicKey as EncryptionPublicKey;
 
 use crate::{
-    api_v2::api_v2_handlers_mcp_servers::{AddMCPServerRequest, DeleteMCPServerResponse, UpdateMCPServerRequest}, node_api_router::{APIUseRegistrationCodeSuccessResponse, SendResponseBody}
+    api_v2::api_v2_handlers_mcp_servers::{AddMCPServerRequest, DeleteMCPServerResponse, UpdateMCPServerRequest},
+    node_api_router::{APIUseRegistrationCodeSuccessResponse, SendResponseBody},
 };
 
 use super::{
-    api_v2::api_v2_handlers_general::InitialRegistrationRequest, node_api_router::{APIError, GetPublicKeysResponse, SendResponseBodyData}
+    api_v2::api_v2_handlers_general::InitialRegistrationRequest,
+    node_api_router::{APIError, GetPublicKeysResponse, SendResponseBodyData},
 };
 
 pub enum NodeCommand {
@@ -384,6 +393,10 @@ pub enum NodeCommand {
     },
     V2ApiListAllMcpShinkaiTools {
         category: Option<String>,
+        res: Sender<Result<Value, APIError>>,
+    },
+    V2ApiListAllNetworkShinkaiTools {
+        bearer: String,
         res: Sender<Result<Value, APIError>>,
     },
     V2ApiListAllShinkaiToolsVersions {


### PR DESCRIPTION
## Summary
- remove the unused `list_all_mcp_shinkai_tools` route
- simplify `list_all_network_shinkai_tools` filtering using `tool_type`
- update node command handling for network tools

## Testing
- `cargo test -p shinkai_http_api --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6840cd21fb688321ac32489d8b8ce641