### PR TITLE
Add list_all_network_tools endpoint

### DIFF
--- a/docs/openapi/workflows.yaml
+++ b/docs/openapi/workflows.yaml
@@ -91,6 +91,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
+  /v2/list_all_network_tools:
+    get:
+      tags:
+      - crate
+      operationId: list_all_network_tools_handler
+      responses:
+        '200':
+          description: Successfully listed all Network tools
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /v2/search_shinkai_tool:
     get:
       tags:

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1207,6 +1207,12 @@ impl Node {
                     .await;
                 });
             }
+            NodeCommand::V2ApiListAllNetworkTools { bearer, res } => {
+                let db_clone = Arc::clone(&self.db);
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_list_all_network_tools(db_clone, bearer, res).await;
+                });
+            }
             NodeCommand::V2ApiListAllMcpShinkaiTools { category, res } => {
                 let db_clone = Arc::clone(&self.db);
                 let tool_router_clone = self.tool_router.clone();

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -382,6 +382,10 @@ pub enum NodeCommand {
         category: Option<String>,
         res: Sender<Result<Value, APIError>>,
     },
+    V2ApiListAllNetworkTools {
+        bearer: String,
+        res: Sender<Result<Value, APIError>>,
+    },
     V2ApiListAllMcpShinkaiTools {
         category: Option<String>,
         res: Sender<Result<Value, APIError>>,


### PR DESCRIPTION
## Summary
- add `V2ApiListAllNetworkTools` node command
- implement `v2_api_list_all_network_tools` with simple Network filter
- expose `/v2/list_all_network_tools` route without category filtering

## Testing
- `cargo test -p shinkai_http_api --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68410e22ecf483219076d19d14d41355