### PR TITLE
Fix relay unregistration on partial connection close

### DIFF
--- a/shinkai-libs/shinkai-libp2p-relayer/src/relay_manager.rs
+++ b/shinkai-libs/shinkai-libp2p-relayer/src/relay_manager.rs
@@ -483,9 +483,13 @@ impl RelayManager {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 println!("📡 Connection established with peer: {}", peer_id);
             }
-            SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+            SwarmEvent::ConnectionClosed { peer_id, cause, remaining_established, .. } => {
                 println!("📡 Connection closed with peer: {} (cause: {:?})", peer_id, cause);
-                self.unregister_peer(&peer_id);
+                if remaining_established == 0 {
+                    self.unregister_peer(&peer_id);
+                } else {
+                    println!("📡 Peer {} still has {} active connection(s) - keeping registration", peer_id, remaining_established);
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- prevent premature unregistration when one of multiple connections closes

## Testing
- `rustfmt shinkai-libs/shinkai-libp2p-relayer/src/relay_manager.rs`
- `cargo check -p shinkai_libp2p_relayer` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6843290b09508321b28901e6680fb264