### PR TITLE
Handle dial failure by queueing retry

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/README_LIBP2P.md
+++ b/shinkai-bin/shinkai-node/src/network/README_LIBP2P.md
@@ -51,6 +51,7 @@ The Node struct has been updated to include:
 3. **Message Sending**: The `send` method has been updated to:
    - First attempt to use libp2p for peer communication
    - Fall back to TCP if libp2p is not available or fails
+   - Dial failures automatically queue the message for retry
 
 4. **Message Receiving**: Incoming libp2p messages are:
    - Received through GossipSub


### PR DESCRIPTION
## Summary
- add pending request tracking for request retries
- requeue messages on dial failure
- note retry behavior in README

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6848dc39e6f483208da3be730b8183eb