### PR TITLE
Handle corrupted Deno download in build script

### DIFF
--- a/shinkai-bin/shinkai-node/Cargo.toml
+++ b/shinkai-bin/shinkai-node/Cargo.toml
@@ -9,6 +9,7 @@ default-run = "shinkai_node"
 
 [build-dependencies]
 shinkai_tools_runner = { workspace = true, features = ["built-in-tools"] }
+zip = "2.2.0"
 
 # Features
 [features]

--- a/shinkai-bin/shinkai-node/build.rs
+++ b/shinkai-bin/shinkai-node/build.rs
@@ -1,6 +1,33 @@
+use std::fs::File;
 use std::path::PathBuf;
 
+use shinkai_tools_runner::copy_assets::DENO_VERSION;
+use zip::ZipArchive;
+
 fn main() {
+    // Path where the build script expects the cached Deno archive
+    let resources_dir = PathBuf::from("./").join("shinkai-tools-runner-resources");
+    let zip_path = resources_dir.join(format!("deno-{}.zip", DENO_VERSION));
+
+    if zip_path.exists() {
+        // Validate that the existing archive is a valid ZIP file
+        let valid_zip = File::open(&zip_path)
+            .and_then(|f| {
+                ZipArchive::new(f)
+                    .map(|_| ())
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            })
+            .is_ok();
+        if !valid_zip {
+            println!(
+                "invalid cached Deno archive detected at {}, removing",
+                zip_path.display()
+            );
+            std::fs::remove_file(&zip_path)
+                .expect("failed to remove corrupted Deno archive");
+        }
+    }
+
     shinkai_tools_runner::copy_assets::copy_assets(
         Some(PathBuf::from("./")),
         Some(PathBuf::from("../../target").join(std::env::var("PROFILE").unwrap())),


### PR DESCRIPTION
## Summary
- check for a valid `deno` zip archive before running the tools runner asset copy
- if the cached zip is invalid, delete it so a fresh copy is downloaded
- add the `zip` crate to build dependencies

## Testing
- `cargo check -p shinkai_node --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6849ba8824e88321bf13198e1782126d