### PR TITLE
Adjust default chat iteration limit

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/inference_chain_router.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/inference_chain_router.rs
@@ -60,15 +60,15 @@ impl JobManager {
         let max_tokens_in_prompt = ModelCapabilitiesManager::get_max_input_tokens(&model);
         let parsed_user_message = ParsedUserMessage::new(job_message.content.to_string());
 
-        // Get max_iterations from preferences, default to 10 if not found
+        // Get max_iterations from preferences, default to 20 if not found
         // Try first as u64, then as String (in case it's stored as a string)
         let max_iterations = match db.get_preference::<u64>("max_iterations") {
             Ok(Some(value)) => value,
             _ => {
                 // If it fails or is None, try as string and parse
                 match db.get_preference::<String>("max_iterations") {
-                    Ok(Some(str_value)) => str_value.parse::<u64>().unwrap_or(10),
-                    _ => 10, // Default if nothing works
+                    Ok(Some(str_value)) => str_value.parse::<u64>().unwrap_or(20),
+                    _ => 20, // Default if nothing works
                 }
             }
         };

--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/inference_chain_trait.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/inference_chain_trait.rs
@@ -607,7 +607,7 @@ impl Default for MockInferenceChainContext {
             user_message,
             image_files: HashMap::new(),
             user_profile,
-            max_iterations: 10,
+            max_iterations: 20,
             iteration_count: 0,
             max_tokens_in_prompt: 1000,
             raw_files: None,


### PR DESCRIPTION
## Summary
- adjust default max_iterations to 20

## Testing
- `rustfmt shinkai-bin/shinkai-node/src/llm_provider/execution/chains/inference_chain_router.rs shinkai-bin/shinkai-node/src/llm_provider/execution/chains/inference_chain_trait.rs`
- `cargo test` *(fails: took too long / heavy compile)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5b2f2c4832180de01a2b44dfb37