### PR TITLE
Add kill_job endpoint

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -17,11 +17,7 @@ impl Node {
                 let listen_address_clone = self.listen_address;
                 let libp2p_manager_clone = self.libp2p_manager.clone();
                 tokio::spawn(async move {
-                    let _ = Self::ping_all(
-                        listen_address_clone,
-                        libp2p_manager_clone,
-                    )
-                    .await;
+                    let _ = Self::ping_all(listen_address_clone, libp2p_manager_clone).await;
                 });
             }
             NodeCommand::GetPublicKeys(sender) => {
@@ -797,6 +793,18 @@ impl Node {
                     let _ = Node::v2_remove_job(db_clone, bearer, job_id, res).await;
                 });
             }
+            NodeCommand::V2ApiKillJob {
+                bearer,
+                conversation_inbox_name,
+                res,
+            } => {
+                let db_clone = self.db.clone();
+                let job_manager_clone = self.job_manager.clone().unwrap();
+                tokio::spawn(async move {
+                    let _ =
+                        Node::v2_api_kill_job(db_clone, job_manager_clone, bearer, conversation_inbox_name, res).await;
+                });
+            }
             NodeCommand::V2ApiVecFSRetrievePathSimplifiedJson { bearer, payload, res } => {
                 let db_clone = Arc::clone(&self.db);
 
@@ -1245,11 +1253,16 @@ impl Node {
                     let _ = Node::v2_api_get_shinkai_tool_metadata(db_clone, bearer, tool_router_key, res).await;
                 });
             }
-            NodeCommand::V2ApiGetToolWithOffering { bearer, tool_key_name, res } => {
+            NodeCommand::V2ApiGetToolWithOffering {
+                bearer,
+                tool_key_name,
+                res,
+            } => {
                 let db_clone = Arc::clone(&self.db);
                 let node_name_clone = self.node_name.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_get_tool_with_offering(db_clone, node_name_clone, bearer, tool_key_name, res).await;
+                    let _ = Node::v2_api_get_tool_with_offering(db_clone, node_name_clone, bearer, tool_key_name, res)
+                        .await;
                 });
             }
             NodeCommand::V2ApiGetToolsWithOfferings { bearer, res } => {
@@ -1669,7 +1682,11 @@ impl Node {
                     let _ = Node::v2_api_get_job_scope(db_clone, bearer, job_id, res).await;
                 });
             }
-            NodeCommand::V2ApiGetMessageTraces { bearer, message_id, res } => {
+            NodeCommand::V2ApiGetMessageTraces {
+                bearer,
+                message_id,
+                res,
+            } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {
                     let _ = Node::v2_api_get_message_traces(db_clone, bearer, message_id, res).await;

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_jobs.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_jobs.rs
@@ -6,21 +6,29 @@ use serde::Deserialize;
 use serde_json::json;
 use shinkai_message_primitives::{
     schemas::{
-        job_config::JobConfig, llm_providers::serialized_llm_provider::{
-            Exo, Gemini, Groq, LLMProviderInterface, Ollama, OpenAI, SerializedLLMProvider, ShinkaiBackend
-        }, shinkai_name::{ShinkaiName, ShinkaiSubidentityType}, smart_inbox::{LLMProviderSubset, V2SmartInbox}
-    }, shinkai_message::{
-        shinkai_message::NodeApiData, shinkai_message_schemas::{
-            APIChangeJobAgentRequest, AssociatedUI, CallbackAction, ExportInboxMessagesFormat, JobCreationInfo, JobMessage, V2ChatMessage
-        }
-    }, shinkai_utils::job_scope::MinimalJobScope
+        job_config::JobConfig,
+        llm_providers::serialized_llm_provider::{
+            Exo, Gemini, Groq, LLMProviderInterface, Ollama, OpenAI, SerializedLLMProvider, ShinkaiBackend,
+        },
+        shinkai_name::{ShinkaiName, ShinkaiSubidentityType},
+        smart_inbox::{LLMProviderSubset, V2SmartInbox},
+    },
+    shinkai_message::{
+        shinkai_message::NodeApiData,
+        shinkai_message_schemas::{
+            APIChangeJobAgentRequest, AssociatedUI, CallbackAction, ExportInboxMessagesFormat, JobCreationInfo,
+            JobMessage, V2ChatMessage,
+        },
+    },
+    shinkai_utils::job_scope::MinimalJobScope,
 };
 use utoipa::{OpenApi, ToSchema};
 use warp::multipart::FormData;
 use warp::Filter;
 
 use crate::{
-    node_api_router::{APIError, SendResponseBody, SendResponseBodyData}, node_commands::NodeCommand
+    node_api_router::{APIError, SendResponseBody, SendResponseBodyData},
+    node_commands::NodeCommand,
 };
 
 use super::api_v2_router::{create_success_response, with_sender};
@@ -167,6 +175,13 @@ pub fn job_routes(
         .and(warp::body::json())
         .and_then(remove_job_handler);
 
+    let kill_job_route = warp::path("kill_job")
+        .and(warp::post())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json())
+        .and_then(kill_job_handler);
+
     let export_messages_from_inbox_route = warp::path("export_messages_from_inbox")
         .and(warp::post())
         .and(with_sender(node_commands_sender.clone()))
@@ -208,6 +223,7 @@ pub fn job_routes(
         .or(get_message_traces_route)
         .or(fork_job_messages_route)
         .or(remove_job_route)
+        .or(kill_job_route)
         .or(export_messages_from_inbox_route)
         .or(add_messages_god_mode_route)
         .or(get_job_provider_route)
@@ -275,6 +291,11 @@ pub struct ForkJobMessagesRequest {
 #[derive(Deserialize, ToSchema)]
 pub struct RemoveJobRequest {
     pub job_id: String,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct KillJobRequest {
+    pub conversation_inbox_name: String,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -1243,6 +1264,42 @@ pub async fn remove_job_handler(
 
 #[utoipa::path(
     post,
+    path = "/v2/kill_job",
+    request_body = KillJobRequest,
+    responses(
+        (status = 200, description = "Successfully killed job", body = String),
+        (status = 400, description = "Bad request", body = APIError),
+        (status = 500, description = "Internal server error", body = APIError)
+    )
+)]
+pub async fn kill_job_handler(
+    node_commands_sender: Sender<NodeCommand>,
+    authorization: String,
+    payload: KillJobRequest,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    node_commands_sender
+        .send(NodeCommand::V2ApiKillJob {
+            bearer,
+            conversation_inbox_name: payload.conversation_inbox_name,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => Ok(warp::reply::with_status(warp::reply::json(&response), StatusCode::OK)),
+        Err(error) => Ok(warp::reply::with_status(
+            warp::reply::json(&error),
+            StatusCode::from_u16(error.code).unwrap(),
+        )),
+    }
+}
+
+#[utoipa::path(
+    post,
     path = "/v2/export_messages_from_inbox",
     request_body = ExportInboxMessagesRequest,
     responses(
@@ -1397,7 +1454,7 @@ pub async fn get_job_provider_handler(
             UpdateJobConfigRequest, UpdateSmartInboxNameRequest, SerializedLLMProvider, JobCreationInfo,
             JobMessage, NodeApiData, LLMProviderSubset, AssociatedUI, MinimalJobScope, CallbackAction, ShinkaiName,
             LLMProviderInterface, RetryMessageRequest, UpdateJobScopeRequest, ExportInboxMessagesFormat, ExportInboxMessagesRequest,
-            ShinkaiSubidentityType, OpenAI, Ollama, Groq, Gemini, Exo, ShinkaiBackend, SendResponseBody, SendResponseBodyData, APIError, GetToolingLogsRequest, GetMessageTracesRequest, ForkJobMessagesRequest, RemoveJobRequest)
+            ShinkaiSubidentityType, OpenAI, Ollama, Groq, Gemini, Exo, ShinkaiBackend, SendResponseBody, SendResponseBodyData, APIError, GetToolingLogsRequest, GetMessageTracesRequest, ForkJobMessagesRequest, RemoveJobRequest, KillJobRequest)
     ),
     tags(
         (name = "jobs", description = "Job API endpoints")

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -283,6 +283,11 @@ pub enum NodeCommand {
         job_id: String,
         res: Sender<Result<SendResponseBody, APIError>>,
     },
+    V2ApiKillJob {
+        bearer: String,
+        conversation_inbox_name: String,
+        res: Sender<Result<String, APIError>>,
+    },
     V2ApiVecFSRetrievePathSimplifiedJson {
         bearer: String,
         payload: APIVecFsRetrievePathSimplifiedJson,


### PR DESCRIPTION
## Summary
- add V2ApiKillJob command and handler
- support kill_job route with docs
- implement `v2_api_kill_job` business logic

## Testing
- `cargo check` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684a643500788321a031b2954e87357c