### PR TITLE
Add tracing for network agent interactions

### DIFF
--- a/shinkai-bin/shinkai-node/src/managers/tool_router.rs
+++ b/shinkai-bin/shinkai-node/src/managers/tool_router.rs
@@ -1135,7 +1135,11 @@ impl ToolRouter {
 
                     // Send a Network Request Invoice
                     let invoice_request = match my_agent_payments_manager
-                        .network_request_invoice(network_tool.clone(), UsageTypeInquiry::PerUse)
+                        .network_request_invoice(
+                            network_tool.clone(),
+                            UsageTypeInquiry::PerUse,
+                            context.message_hash_id(),
+                        )
                         .await
                     {
                         Ok(request) => request,

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_my_agent_offers.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_my_agent_offers.rs
@@ -69,7 +69,10 @@ impl Node {
         let manager = my_agent_payments_manager.lock().await;
 
         // Request the invoice
-        match manager.network_request_invoice(network_tool, usage).await {
+        match manager
+            .network_request_invoice(network_tool, usage, None)
+            .await
+        {
             Ok(invoice_request) => {
                 let invoice_value = match serde_json::to_value(invoice_request) {
                     Ok(value) => value,
@@ -213,7 +216,12 @@ impl Node {
         let payment = match my_agent_offerings_manager
             .lock()
             .await
-            .pay_invoice_and_send_receipt(invoice_id, data_for_tool, node_name.clone())
+            .pay_invoice_and_send_receipt(
+                invoice_id,
+                data_for_tool,
+                node_name.clone(),
+                None,
+            )
             .await
         {
             Ok(payment) => payment,


### PR DESCRIPTION
## Summary
- trace invoice request, payment, and results in agent payment workflow
- hook tracing into network handlers for invoices and results
- propagate optional tracing IDs through network request and payment APIs

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684b4dd6c2f883218cac9cbf7903f024