### PR TITLE
Fix tool offering cleanup on tool removal

### DIFF
--- a/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
+++ b/shinkai-libs/shinkai-sqlite/src/shinkai_tool_manager.rs
@@ -619,6 +619,12 @@ impl SqliteManager {
             tx.execute("DELETE FROM shinkai_tools_vec_items WHERE rowid = ?1", params![rowid])?;
         }
 
+        // Also remove any tool offering associated with this tool key
+        tx.execute(
+            "DELETE FROM tool_micropayments_requirements WHERE tool_key = ?1",
+            params![tool_key_lower],
+        )?;
+
         tx.commit()?;
 
         // Now remove those rowids from the FTS table in the separate in-memory DB


### PR DESCRIPTION
## Summary
- ensure removing a tool also deletes any associated offerings

## Testing
- `IS_TESTING=1 cargo test -- --test-threads=1` *(fails: process timed out or produced no results)*

------
https://chatgpt.com/codex/tasks/task_e_6851854257a08321afe8e407b06b0492