### PR TITLE
Add invoice rejection

### DIFF
--- a/docs/openapi/wallet.yaml
+++ b/docs/openapi/wallet.yaml
@@ -56,6 +56,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
+  /v2/reject_invoice:
+    post:
+      tags:
+      - crate
+      operationId: reject_invoice_handler
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RejectInvoiceRequest'
+        required: true
+      responses:
+        '200':
+          description: Successfully rejected invoice
+          content:
+            application/json:
+              schema: {}
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /v2/restore_coinbase_mpc_wallet:
     post:
       tags:
@@ -259,6 +282,16 @@ components:
         data_for_tool: {}
         invoice_id:
           type: string
+    RejectInvoiceRequest:
+      type: object
+      required:
+      - invoice_id
+      properties:
+        invoice_id:
+          type: string
+        reason:
+          type: string
+          nullable: true
     RestoreCoinbaseMPCWalletRequest:
       type: object
       required:

--- a/shinkai-bin/shinkai-node/src/managers/tool_router.rs
+++ b/shinkai-bin/shinkai-node/src/managers/tool_router.rs
@@ -1329,6 +1329,12 @@ impl ToolRouter {
                                 invoice_result = invoice;
                                 break;
                             }
+
+                            if invoice.status == InvoiceStatusEnum::Rejected {
+                                return Err(LLMProviderError::FunctionExecutionError(
+                                    "Invoice rejected".to_string(),
+                                ));
+                            }
                         }
                         Err(e) => {
                             return Err(LLMProviderError::FunctionExecutionError(format!(

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
@@ -588,6 +588,73 @@ pub async fn pay_invoice_and_send_receipt(
 
         Ok(())
     }
+
+    /// Send an invoice result back to the provider
+    pub async fn send_invoice_result_to_provider(&self, invoice: &Invoice) -> Result<(), AgentOfferingManagerError> {
+        if let Some(identity_manager_arc) = self.identity_manager.upgrade() {
+            let identity_manager = identity_manager_arc.lock().await;
+            let standard_identity = identity_manager
+                .external_profile_to_global_identity(&invoice.provider_name.to_string(), None)
+                .await
+                .map_err(|e| AgentOfferingManagerError::OperationFailed(e))?;
+            drop(identity_manager);
+            let receiver_public_key = standard_identity.node_encryption_public_key;
+
+            let message = ShinkaiMessageBuilder::create_generic_invoice_message(
+                invoice.clone(),
+                MessageSchemaType::InvoiceResult,
+                clone_static_secret_key(&self.my_encryption_secret_key),
+                clone_signature_secret_key(&self.my_signature_secret_key),
+                receiver_public_key,
+                self.node_name.to_string(),
+                "".to_string(),
+                invoice.provider_name.to_string(),
+                "main".to_string(),
+                None,
+            )
+            .map_err(|e| AgentOfferingManagerError::OperationFailed(e.to_string()))?;
+
+            send_message_to_peer(
+                message,
+                self.db.clone(),
+                standard_identity,
+                self.my_encryption_secret_key.clone(),
+                self.identity_manager.clone(),
+                self.proxy_connection_info.clone(),
+                self.libp2p_event_sender.clone(),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Reject an invoice and notify the provider
+    pub async fn reject_invoice_and_notify(
+        &self,
+        invoice_id: String,
+        reason: Option<String>,
+    ) -> Result<Invoice, AgentOfferingManagerError> {
+        let db = self
+            .db
+            .upgrade()
+            .ok_or_else(|| AgentOfferingManagerError::OperationFailed("Failed to upgrade db reference".to_string()))?;
+
+        let mut invoice = db
+            .get_invoice(&invoice_id)
+            .map_err(|e| AgentOfferingManagerError::OperationFailed(format!("Failed to get invoice: {:?}", e)))?;
+
+        invoice.update_status(InvoiceStatusEnum::Rejected);
+        invoice.result_str = Some(reason.clone().unwrap_or_else(|| "Rejected by user".to_string()));
+        invoice.response_date_time = Some(chrono::Utc::now());
+
+        db.set_invoice(&invoice)
+            .map_err(|e| AgentOfferingManagerError::OperationFailed(format!("Failed to store invoice: {:?}", e)))?;
+
+        self.send_invoice_result_to_provider(&invoice).await?;
+
+        Ok(invoice)
+    }
     /// Add a network tool
     ///
     /// # Arguments

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1526,6 +1526,21 @@ impl Node {
                     .await;
                 });
             }
+            NodeCommand::V2ApiRejectInvoice { bearer, invoice_id, reason, res } => {
+                let db_clone = Arc::clone(&self.db);
+                let my_agent_payments_manager_clone = self.my_agent_payments_manager.clone();
+                tokio::spawn(async move {
+                    let _ = Node::v2_api_reject_invoice(
+                        db_clone,
+                        my_agent_payments_manager_clone,
+                        bearer,
+                        invoice_id,
+                        reason,
+                        res,
+                    )
+                    .await;
+                });
+            }
             NodeCommand::V2ApiListInvoices { bearer, res } => {
                 let db_clone = Arc::clone(&self.db);
                 tokio::spawn(async move {

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_wallets.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_wallets.rs
@@ -35,6 +35,13 @@ pub fn wallet_routes(
         .and(warp::body::json())
         .and_then(pay_invoice_handler);
 
+    let reject_invoice_route = warp::path("reject_invoice")
+        .and(warp::post())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json())
+        .and_then(reject_invoice_handler);
+
     let restore_coinbase_mpc_wallet_route = warp::path("restore_coinbase_mpc_wallet")
         .and(warp::post())
         .and(with_sender(node_commands_sender.clone()))
@@ -57,6 +64,7 @@ pub fn wallet_routes(
     restore_local_wallet_route
         .or(create_local_wallet_route)
         .or(pay_invoice_route)
+        .or(reject_invoice_route)
         .or(restore_coinbase_mpc_wallet_route)
         .or(list_wallets_route)
         .or(get_wallet_balance_route)
@@ -150,6 +158,12 @@ pub struct PayInvoiceRequest {
     pub data_for_tool: Value,
 }
 
+#[derive(Deserialize, ToSchema)]
+pub struct RejectInvoiceRequest {
+    pub invoice_id: String,
+    pub reason: Option<String>,
+}
+
 #[utoipa::path(
     post,
     path = "/v2/pay_invoice",
@@ -171,6 +185,40 @@ pub async fn pay_invoice_handler(
             bearer,
             invoice_id: payload.invoice_id,
             data_for_tool: payload.data_for_tool,
+            res: res_sender,
+        })
+        .await
+        .map_err(|_| warp::reject::reject())?;
+
+    let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
+
+    match result {
+        Ok(response) => Ok(warp::reply::json(&response)),
+        Err(error) => Err(warp::reject::custom(error)),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v2/reject_invoice",
+    request_body = RejectInvoiceRequest,
+    responses(
+        (status = 200, description = "Successfully rejected invoice", body = Value),
+        (status = 500, description = "Internal server error", body = APIError)
+    )
+)]
+pub async fn reject_invoice_handler(
+    sender: Sender<NodeCommand>,
+    authorization: String,
+    payload: RejectInvoiceRequest,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let bearer = authorization.strip_prefix("Bearer ").unwrap_or("").to_string();
+    let (res_sender, res_receiver) = async_channel::bounded(1);
+    sender
+        .send(NodeCommand::V2ApiRejectInvoice {
+            bearer,
+            invoice_id: payload.invoice_id,
+            reason: payload.reason,
             res: res_sender,
         })
         .await
@@ -291,10 +339,11 @@ pub async fn get_wallet_balance_handler(
         restore_local_wallet_handler,
         create_local_wallet_handler,
         pay_invoice_handler,
+        reject_invoice_handler,
         restore_coinbase_mpc_wallet_handler,
     ),
     components(
-        schemas(APIError, CreateLocalWalletRequest, PayInvoiceRequest, RestoreCoinbaseMPCWalletRequest, RestoreLocalWalletRequest,
+        schemas(APIError, CreateLocalWalletRequest, PayInvoiceRequest, RejectInvoiceRequest, RestoreCoinbaseMPCWalletRequest, RestoreLocalWalletRequest,
             NetworkProtocolFamilyEnum, WalletRole, WalletSource, CoinbaseMPCWalletConfig, Address, Asset)
     ),
     tags(

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -585,6 +585,12 @@ pub enum NodeCommand {
         data_for_tool: Value,
         res: Sender<Result<Value, APIError>>,
     },
+    V2ApiRejectInvoice {
+        bearer: String,
+        invoice_id: String,
+        reason: Option<String>,
+        res: Sender<Result<Value, APIError>>,
+    },
     V2ApiListInvoices {
         bearer: String,
         res: Sender<Result<Value, APIError>>,

--- a/shinkai-libs/shinkai-message-primitives/src/schemas/invoices.rs
+++ b/shinkai-libs/shinkai-message-primitives/src/schemas/invoices.rs
@@ -59,6 +59,7 @@ pub enum InvoiceStatusEnum {
     Paid,
     Failed,
     Processed,
+    Rejected,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- allow marking an invoice as `Rejected`
- send invoice result to provider on rejection
- expose new `/v2/reject_invoice` API
- document RejectInvoiceRequest in OpenAPI
- wire new command through NodeCommand and handlers

## Testing
- `cargo check`
- `cargo test --quiet` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6853103924048321a25434c87055f241