### PR TITLE
Add inbox tracking to network invoice requests

### DIFF
--- a/shinkai-bin/shinkai-node/src/managers/tool_router.rs
+++ b/shinkai-bin/shinkai-node/src/managers/tool_router.rs
@@ -1144,10 +1144,13 @@ impl ToolRouter {
                     };
 
                     // Send a Network Request Invoice
+                    let inbox_name = Some(context.full_job().conversation_inbox_name.to_string());
+
                     let invoice_request = match my_agent_payments_manager
                         .network_request_invoice(
                             network_tool.clone(),
                             UsageTypeInquiry::PerUse,
+                            inbox_name,
                             context.message_hash_id(),
                         )
                         .await

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
@@ -138,6 +138,7 @@ impl MyAgentOfferingsManager {
         &self,
         network_tool: NetworkTool,
         usage_type_inquiry: UsageTypeInquiry,
+        inbox_name: Option<String>,
         tracing_message_id: Option<String>,
     ) -> Result<InternalInvoiceRequest, AgentOfferingManagerError> {
         // Request the invoice
@@ -193,7 +194,7 @@ impl MyAgentOfferingsManager {
                 "tool": network_tool.name,
                 "usage_type": usage_clone
             });
-            if let Err(e) = db.add_tracing(&trace_id, None, "invoice_request_sent", &trace_info) {
+            if let Err(e) = db.add_tracing(&trace_id, inbox_name.as_deref(), "invoice_request_sent", &trace_info) {
                 eprintln!("failed to add tracing: {:?}", e);
             }
         }

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1509,6 +1509,7 @@ impl Node {
                 bearer,
                 tool_key_name,
                 usage,
+                inbox_name,
                 res,
             } => {
                 let db_clone = Arc::clone(&self.db);
@@ -1520,6 +1521,7 @@ impl Node {
                         bearer,
                         tool_key_name,
                         usage,
+                        inbox_name,
                         res,
                     )
                     .await;

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_my_agent_offers.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_my_agent_offers.rs
@@ -22,6 +22,7 @@ impl Node {
         bearer: String,
         tool_key_name: String,
         usage: UsageTypeInquiry,
+        inbox_name: Option<String>,
         res: Sender<Result<Value, APIError>>,
     ) -> Result<(), NodeError> {
         // Validate the bearer token
@@ -70,7 +71,7 @@ impl Node {
 
         // Request the invoice
         match manager
-            .network_request_invoice(network_tool, usage, None)
+            .network_request_invoice(network_tool, usage, inbox_name.clone(), None)
             .await
         {
             Ok(invoice_request) => {

--- a/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
@@ -770,6 +770,7 @@ fn micropayment_flow_test() {
                         bearer: api_v2_key.to_string(),
                         tool_key_name: test_network_tool_name.to_string(),
                         usage: UsageTypeInquiry::PerUse,
+                        inbox_name: None,
                         res: sender,
                     })
                     .await

--- a/shinkai-bin/shinkai-node/tests/it/a4_micropayment_localhost_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/a4_micropayment_localhost_tests.rs
@@ -785,6 +785,7 @@ fn micropayment_localhost_flow_test() {
                         bearer: api_v2_key.to_string(),
                         tool_key_name: test_network_tool_name.to_string(),
                         usage: UsageTypeInquiry::PerUse,
+                        inbox_name: None,
                         res: sender,
                     })
                     .await

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -555,6 +555,7 @@ pub enum NodeCommand {
         bearer: String,
         tool_key_name: String,
         usage: UsageTypeInquiry,
+        inbox_name: Option<String>,
         res: Sender<Result<Value, APIError>>,
     },
     V2ApiPayInvoice {


### PR DESCRIPTION
## Summary
- include conversation inbox when requesting invoices from tools
- record tracing data with this inbox name

## Testing
- `cargo check`
- `cargo test -q --no-run` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6854512751988321a1707ed42845f49c