### PR TITLE
Update agent offering API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ shinkai-libs/shinkai-non-rust-code/internal_tools_storage
 shinkai-bin/shinkai-node/storage_test_node
 storage_debug_node2_test
 storage_debug_node1_test
+storage_debug_nico_testnet1
+storage_debug_nico_testnet2

--- a/docs/openapi/tool_offerings.yaml
+++ b/docs/openapi/tool_offerings.yaml
@@ -264,10 +264,13 @@ components:
     GetAgentNetworkOfferingRequest:
       type: object
       required:
-      - agent_identity
+      - node_name
       properties:
-        agent_identity:
+        node_name:
           type: string
+        auto_check:
+          type: boolean
+          default: true
         tool_offering:
           $ref: '#/components/schemas/ShinkaiToolOffering'
     ShinkaiToolOffering:

--- a/shinkai-bin/shinkai-node/src/managers/model_capabilities_manager.rs
+++ b/shinkai-bin/shinkai-node/src/managers/model_capabilities_manager.rs
@@ -199,6 +199,9 @@ impl ModelCapabilitiesManager {
             model_type if model_type.contains("minicpm-v") => {
                 vec![ModelCapability::TextInference, ModelCapability::ImageAnalysis]
             }
+            model_type if model_type.starts_with("gemma3n") => {
+                vec![ModelCapability::TextInference]
+            }
             model_type if model_type.starts_with("regex") => {
                 vec![ModelCapability::TextInference, ModelCapability::ImageAnalysis]
             }
@@ -684,6 +687,7 @@ impl ModelCapabilitiesManager {
             model_type if model_type.starts_with("command-r7b") => 128_000,
             model_type if model_type.starts_with("mistral-small") => 128_000,
             model_type if model_type.starts_with("qwq") => 32_000,
+            model_type if model_type.starts_with("gemma3n") => 32_000,
             model_type if model_type.starts_with("gemma3:1b") => 32_000,
             model_type if model_type.starts_with("gemma3:4b") => 128_000,
             model_type if model_type.starts_with("gemma3:12b") => 128_000,
@@ -912,6 +916,7 @@ impl ModelCapabilitiesManager {
                     || model.model_type.starts_with("mistral-pixtral")
                     || model.model_type.starts_with("qwen2.5-coder")
                     || model.model_type.starts_with("qwq")
+                    || model.model_type.starts_with("gemma3n")
                     || model.model_type.starts_with("gemma3")
                     || model.model_type.starts_with("qwen3")
                     || model.model_type.starts_with("deepseek-r1:14b")
@@ -961,6 +966,7 @@ impl ModelCapabilitiesManager {
                     || model.model_type.starts_with("mistral-small")
                     || model.model_type.starts_with("mistral-large")
                     || model.model_type.starts_with("mistral-pixtral")
+                    || model.model_type.starts_with("gemma3n")
             }
             LLMProviderInterface::Claude(_) => true, // All Claude models support tool calling
             LLMProviderInterface::ShinkaiBackend(_) => true,

--- a/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
+++ b/shinkai-bin/shinkai-node/src/network/agent_payments_manager/my_agent_offerings_manager.rs
@@ -527,17 +527,17 @@ impl MyAgentOfferingsManager {
         Ok(())
     }
 
-    pub fn store_agent_network_offering(&self, node_name: String, offerings: Vec<ShinkaiToolOffering>) {
-        self.agent_network_offerings.insert(
-            node_name,
-            (serde_json::to_value(offerings).unwrap_or(Value::Null), Utc::now()),
-        );
+    pub fn store_agent_network_offering(&self, node_name: String, offerings: Vec<Value>) {
+        // Store offerings directly as a JSON array instead of double-serializing
+        let offerings_value = Value::Array(offerings);
+        self.agent_network_offerings
+            .insert(node_name, (offerings_value, Utc::now()));
     }
 
-    pub fn get_agent_network_offering(&self, node_name: &str) -> Option<(Vec<ShinkaiToolOffering>, DateTime<Utc>)> {
+    pub fn get_agent_network_offering(&self, node_name: &str) -> Option<(Vec<Value>, DateTime<Utc>)> {
         self.agent_network_offerings.get(node_name).map(|v| {
             let (value, timestamp) = v.value().clone();
-            let offerings = serde_json::from_value::<Vec<ShinkaiToolOffering>>(value).unwrap_or_default();
+            let offerings = serde_json::from_value::<Vec<Value>>(value).unwrap_or_default();
             (offerings, timestamp)
         })
     }

--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1367,13 +1367,22 @@ impl Node {
             }
             NodeCommand::V2ApiGetAgentNetworkOffering {
                 bearer,
-                identity,
+                node_name,
+                auto_check,
                 res,
             } => {
                 let db_clone = Arc::clone(&self.db);
                 let my_agent_payments_manager_clone = self.my_agent_payments_manager.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_get_agent_network_offering(db_clone, my_agent_payments_manager_clone, bearer, identity, res).await;
+                    let _ = Node::v2_api_get_agent_network_offering(
+                        db_clone,
+                        my_agent_payments_manager_clone,
+                        bearer,
+                        node_name,
+                        auto_check,
+                        res,
+                    )
+                    .await;
                 });
             }
             NodeCommand::V2ApiRemoveToolOffering {

--- a/shinkai-bin/shinkai-node/src/network/network_manager/network_handlers.rs
+++ b/shinkai-bin/shinkai-node/src/network/network_manager/network_handlers.rs
@@ -781,7 +781,7 @@ pub async fn handle_network_message_cases(
                     } else {
                         return Ok(());
                     };
-                    if let Ok(req) = serde_json::from_str::<AgentNetworkOfferingRequest>(
+                    if let Ok(_req) = serde_json::from_str::<AgentNetworkOfferingRequest>(
                         &message.get_message_content().unwrap_or_default(),
                     ) {
                         let ext_manager = ext_agent_offering_manager.lock().await;
@@ -799,16 +799,15 @@ pub async fn handle_network_message_cases(
                         return Ok(());
                     };
 
-                    if let Ok(resp) = serde_json::from_str::<AgentNetworkOfferingResponse>(
-                        &message.get_message_content().unwrap_or_default(),
-                    ) {
+                    // The new format is a direct array of combined objects containing network_tool and tool_offering
+                    if let Ok(combined_offerings) =
+                        serde_json::from_str::<Vec<Value>>(&message.get_message_content().unwrap_or_default())
+                    {
                         let my_manager = my_manager.lock().await;
-                        if let Some(offerings) = resp.offerings {
-                            my_manager.store_agent_network_offering(requester.to_string(), offerings);
-                        }
+                        my_manager.store_agent_network_offering(requester.to_string(), combined_offerings);
                     } else {
                         eprintln!(
-                            "Failed to deserialize JSON to AgentNetworkOfferingResponse: {:?}",
+                            "Failed to deserialize JSON to combined offerings array: {:?}",
                             message.get_message_content()
                         );
                     }

--- a/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
@@ -769,7 +769,10 @@ fn micropayment_flow_test() {
                         println!("val: {:?}", val);
                         if let Some(offerings) = val.get("offerings") {
                             if let Some(offerings_array) = offerings.as_array() {
-                                !offerings_array.is_empty()
+                                // Check that offerings array is not empty and contains valid offering objects
+                                !offerings_array.is_empty() && offerings_array.iter().all(|offering| {
+                                    offering.get("network_tool").is_some() && offering.get("tool_offering").is_some()
+                                })
                             } else {
                                 false
                             }

--- a/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
@@ -756,7 +756,8 @@ fn micropayment_flow_test() {
                     node2_commands_sender
                         .send(NodeCommand::V2ApiGetAgentNetworkOffering {
                             bearer: api_v2_key.to_string(),
-                            identity: node1_identity_name.to_string(),
+                            node_name: node1_identity_name.to_string(),
+                            auto_check: true,
                             res: sender,
                         })
                         .await

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ext_agent_offers.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ext_agent_offers.rs
@@ -84,9 +84,15 @@ pub struct GetToolWithOfferingRequest {
     pub tool_key_name: String,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Deserialize, ToSchema)]
 pub struct GetAgentNetworkOfferingRequest {
-    pub agent_identity: String,
+    pub node_name: String,
+    #[serde(default = "default_true")]
+    pub auto_check: bool,
 }
 
 #[utoipa::path(
@@ -343,7 +349,8 @@ pub async fn get_agent_network_offering_handler(
     node_commands_sender
         .send(NodeCommand::V2ApiGetAgentNetworkOffering {
             bearer,
-            identity: payload.agent_identity,
+            node_name: payload.node_name,
+            auto_check: payload.auto_check,
             res: res_sender,
         })
         .await

--- a/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ext_agent_offers.rs
+++ b/shinkai-libs/shinkai-http-api/src/api_v2/api_v2_handlers_ext_agent_offers.rs
@@ -56,12 +56,20 @@ pub fn ext_agent_offers_routes(
         .and(warp::header::<String>("authorization"))
         .and_then(get_all_tool_offerings_handler);
 
+    let get_agent_network_offering_route = warp::path("get_agent_network_offering")
+        .and(warp::post())
+        .and(with_sender(node_commands_sender.clone()))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json())
+        .and_then(get_agent_network_offering_handler);
+
     set_tool_offering_route
         .or(get_tool_offering_route)
         .or(remove_tool_offering_route)
         .or(get_all_tool_offerings_route)
         .or(get_tool_with_offering_route)
         .or(get_tools_with_offerings_route)
+        .or(get_agent_network_offering_route)
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -283,10 +291,7 @@ pub async fn get_tool_with_offering_handler(
     let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
 
     match result {
-        Ok(info) => Ok(warp::reply::with_status(
-            warp::reply::json(&info),
-            StatusCode::OK,
-        )),
+        Ok(info) => Ok(warp::reply::with_status(warp::reply::json(&info), StatusCode::OK)),
         Err(error) => Ok(warp::reply::with_status(
             warp::reply::json(&error),
             StatusCode::from_u16(error.code).unwrap(),
@@ -319,16 +324,14 @@ pub async fn get_tools_with_offerings_handler(
     let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
 
     match result {
-        Ok(info) => Ok(warp::reply::with_status(
-            warp::reply::json(&info),
-            StatusCode::OK,
-        )),
+        Ok(info) => Ok(warp::reply::with_status(warp::reply::json(&info), StatusCode::OK)),
         Err(error) => Ok(warp::reply::with_status(
             warp::reply::json(&error),
             StatusCode::from_u16(error.code).unwrap(),
         )),
     }
 }
+
 #[utoipa::path(
     post,
     path = "/v2/get_agent_network_offering",
@@ -357,17 +360,13 @@ pub async fn get_agent_network_offering_handler(
         .map_err(|_| warp::reject::reject())?;
     let result = res_receiver.recv().await.map_err(|_| warp::reject::reject())?;
     match result {
-        Ok(info) => Ok(warp::reply::with_status(
-            warp::reply::json(&info),
-            StatusCode::OK,
-        )),
+        Ok(info) => Ok(warp::reply::with_status(warp::reply::json(&info), StatusCode::OK)),
         Err(error) => Ok(warp::reply::with_status(
             warp::reply::json(&error),
             StatusCode::from_u16(error.code).unwrap(),
         )),
     }
 }
-
 
 #[derive(OpenApi)]
 #[openapi(
@@ -377,11 +376,12 @@ pub async fn get_agent_network_offering_handler(
         remove_tool_offering_handler,
         get_all_tool_offerings_handler,
         get_tool_with_offering_handler,
-        get_tools_with_offerings_handler
+        get_tools_with_offerings_handler,
+        get_agent_network_offering_handler
     ),
     components(
         schemas(ShinkaiToolOffering, APIError, GetToolOfferingRequest, UsageType, ToolPrice, PaymentRequirements, Asset, NetworkIdentifier,
-            RemoveToolOfferingRequest, SetToolOfferingRequest, GetToolWithOfferingRequest)
+            RemoveToolOfferingRequest, SetToolOfferingRequest, GetToolWithOfferingRequest, GetAgentNetworkOfferingRequest)
     ),
     tags(
         (name = "tool_offerings", description = "Tool Offering API endpoints")

--- a/shinkai-libs/shinkai-http-api/src/node_commands.rs
+++ b/shinkai-libs/shinkai-http-api/src/node_commands.rs
@@ -517,7 +517,8 @@ pub enum NodeCommand {
     },
     V2ApiGetAgentNetworkOffering {
         bearer: String,
-        identity: String,
+        node_name: String,
+        auto_check: bool,
         res: Sender<Result<Value, APIError>>,
     },
     V2ApiRestoreLocalEthersWallet {


### PR DESCRIPTION
## Summary
- switch `get_agent_network_offering` to use a node name rather than agent identity
- add optional `auto_check` parameter to poll for results
- adjust HTTP handler, command enum and command handler
- update OpenAPI spec and integration test

## Testing
- `cargo check`
- `cargo test -q --no-run`


------
https://chatgpt.com/codex/tasks/task_e_685da2138a688321baf5f1d5f1a42322