### PR TITLE
Implement wait loop for network offering

### DIFF
--- a/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
+++ b/shinkai-bin/shinkai-node/src/network/handle_commands_list.rs
@@ -1373,7 +1373,14 @@ impl Node {
                 let db_clone = Arc::clone(&self.db);
                 let my_agent_payments_manager_clone = self.my_agent_payments_manager.clone();
                 tokio::spawn(async move {
-                    let _ = Node::v2_api_get_agent_network_offering(db_clone, my_agent_payments_manager_clone, bearer, identity, res).await;
+                    let _ = Node::v2_api_get_agent_network_offering(
+                        db_clone,
+                        my_agent_payments_manager_clone,
+                        bearer,
+                        identity,
+                        res,
+                    )
+                    .await;
                 });
             }
             NodeCommand::V2ApiRemoveToolOffering {

--- a/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ext_agent_offers.rs
+++ b/shinkai-bin/shinkai-node/src/network/v2_api/api_v2_commands_ext_agent_offers.rs
@@ -402,20 +402,20 @@ impl Node {
         db: Arc<SqliteManager>,
         my_agent_offerings_manager: Arc<Mutex<MyAgentOfferingsManager>>,
         bearer: String,
-        identity: String,
+        node_name: String,
         res: Sender<Result<Value, APIError>>,
     ) -> Result<(), NodeError> {
         if Self::validate_bearer_token(&bearer, db.clone(), &res).await.is_err() {
             return Ok(());
         }
 
-        let identity = match ShinkaiName::new(identity) {
+        let node_name = match ShinkaiName::new(node_name) {
             Ok(name) => name,
             Err(_) => {
                 let api_error = APIError {
                     code: StatusCode::BAD_REQUEST.as_u16(),
                     error: "Bad Request".to_string(),
-                    message: "Invalid identity".to_string(),
+                    message: "Invalid node name".to_string(),
                 };
                 let _ = res.send(Err(api_error)).await;
                 return Ok(());
@@ -424,8 +424,11 @@ impl Node {
 
         {
             let manager = my_agent_offerings_manager.lock().await;
-            let _ = manager.request_agent_network_offering(identity.clone()).await;
-            if let Some((offerings, ts)) = manager.get_agent_network_offering(&identity.to_string()) {
+            let _ = manager.request_agent_network_offering(node_name.clone()).await;
+            if let Some((offerings, ts)) = manager
+                .get_agent_network_offering(node_name.to_string(), true)
+                .await
+            {
                 let value = json!({"offerings": offerings, "last_updated": ts.to_rfc3339()});
                 let _ = res.send(Ok(value)).await;
             } else {


### PR DESCRIPTION
## Summary
- support waiting on network agent offering
- update agent offering API to use node names

## Testing
- `cargo check`
- `cargo test --no-run` *(fails: too resource-heavy for environment)*

------
https://chatgpt.com/codex/tasks/task_e_685da2138a688321baf5f1d5f1a42322