### PR TITLE
Update inference chain to add default tool search

### DIFF
--- a/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/generic_chain/generic_inference_chain.rs
+++ b/shinkai-bin/shinkai-node/src/llm_provider/execution/chains/generic_chain/generic_inference_chain.rs
@@ -758,6 +758,31 @@ impl GenericInferenceChain {
                                         }
                                     }
                                 }
+
+                                // Include default tools if available
+                                let default_tool_keys = vec![
+                                    "local:::__official_shinkai:::google_search",
+                                    "local:::__official_shinkai:::download_pages",
+                                    "local:::__official_shinkai:::youtube_transcript_extractor_2_0",
+                                ];
+
+                                for key in default_tool_keys {
+                                    match tool_router.get_tool_by_name(key).await {
+                                        Ok(Some(tool)) => {
+                                            let key_no_version = tool.tool_router_key().to_string_without_version();
+                                            if !tools.iter().any(|t| t.tool_router_key().to_string_without_version() == key_no_version) {
+                                                tools.push(tool);
+                                            }
+                                        }
+                                        Ok(None) => {}
+                                        Err(e) => {
+                                            return Err(LLMProviderError::ToolRetrievalError(format!(
+                                                "Error retrieving tool: {:?}",
+                                                e
+                                            )));
+                                        }
+                                    }
+                                }
                             }
                             Err(e) => {
                                 return Err(LLMProviderError::ToolSearchError(format!(


### PR DESCRIPTION
## Summary
- ensure certain default tools are appended when the inference chain uses vector search

## Testing
- `cargo test --no-run` *(fails: build terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68855b93ea088321ae31ac393dfdfba1