### PR TITLE
chore: remove embedded secrets from micropayment tests

### DIFF
--- a/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/a3_micropayment_flow_tests.rs
@@ -125,9 +125,6 @@ fn micropayment_flow_test() {
     std::env::set_var("IS_TESTING", "1");
     std::env::set_var("ADD_TESTING_NETWORK_ECHO", "true");
     std::env::set_var("ADD_TESTING_EXTERNAL_NETWORK_ECHO", "true");
-    std::env::set_var("X402_PAY_TO", "0x1Ae4cAa1be596f94f03a63203E1Dc5fD2856edd1");
-    std::env::set_var("X402_PRIVATE_KEY", "0x2a5cd0fff014d6277bf35dda98e2ad8d8d9187c796fb85ff13f1e0ec771c3425");
-    std::env::set_var("RESTORE_WALLET_MNEMONICS_NODE2", "scout nation glad ignore large coral basic police budget vital protect chaos");
 
     setup();
     let rt = Runtime::new().unwrap();

--- a/shinkai-bin/shinkai-node/tests/it/a4_micropayment_localhost_tests.rs
+++ b/shinkai-bin/shinkai-node/tests/it/a4_micropayment_localhost_tests.rs
@@ -125,9 +125,6 @@ fn micropayment_localhost_flow_test() {
     std::env::set_var("IS_TESTING", "1");
     std::env::set_var("ADD_TESTING_NETWORK_ECHO", "true");
     std::env::set_var("ADD_TESTING_EXTERNAL_NETWORK_ECHO", "true");
-    std::env::set_var("X402_PAY_TO", "0x1Ae4cAa1be596f94f03a63203E1Dc5fD2856edd1");
-    std::env::set_var("X402_PRIVATE_KEY", "0x2a5cd0fff014d6277bf35dda98e2ad8d8d9187c796fb85ff13f1e0ec771c3425");
-    std::env::set_var("RESTORE_WALLET_MNEMONICS_NODE2", "scout nation glad ignore large coral basic police budget vital protect chaos");
 
     setup();
     let rt = Runtime::new().unwrap();


### PR DESCRIPTION
## Summary
- remove hardcoded X402 and mnemonic test secrets

## Testing
- `cargo test --locked -p shinkai_node` *(fails: command terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2ad4d7ec8320853d3185a247d0dd